### PR TITLE
Update Makefile build scripts to allow building debug-version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ builds:
     main: ./cmd/rport
     binary: rport
     ldflags:
-      - "-s -w  -X {{.Env.PROJECT}}/share.BuildVersion={{.Version}}"
+      - "-s -w -X {{.Env.PROJECT}}/share.BuildVersion={{.Version}}"
     goos:
       - linux
       - darwin
@@ -40,7 +40,7 @@ builds:
     main: ./cmd/rportd
     binary: rportd
     ldflags:
-      - "-s -w  -X {{.Env.PROJECT}}/share.BuildVersion={{.Version}}"
+      - "-s -w -X {{.Env.PROJECT}}/share.BuildVersion={{.Version}}"
     goos:
       - linux
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ BINARIES=rport rportd
 all: test build
 
 build:
-	$(foreach BINARY,$(BINARIES),go build -o $(BINARY) -v ./cmd/$(BINARY)/...;)
+	CGO_ENABLED=0 $(foreach BINARY,$(BINARIES),go build -ldflags "-s -w" -o $(BINARY) -v ./cmd/$(BINARY)/...;)
+
+build-debug:
+	$(foreach BINARY,$(BINARIES),go build -race -gcflags "all=-N -l" -o $(BINARY) -v ./cmd/$(BINARY)/...;)
 
 test:
 	go test -v ./...


### PR DESCRIPTION
Now 'build' builds minimalistic version and 'build-debug' builds version with debug symbols and race detection, allowing to run delve session