### PR TITLE
Add authorization checks for API and API documentation

### DIFF
--- a/api-doc.yml
+++ b/api-doc.yml
@@ -1,0 +1,212 @@
+swagger: "2.0"
+info:
+  description: "To run API handler, use `--api-addr=0.0.0.0:8888` CLI argument"
+  version: "1.0.0"
+  title: "rportd HTTP API"
+host: "yourserver:8888"
+basePath: "/api/v1"
+securityDefinitions:
+  basic_auth:
+    type: basic
+    description: "HTTP-basic authentication works for all routes"
+  bearer_auth:
+    description: "Instead of HTTP basic authentication you can retrieve a bearer token using /login endpoint. Send the retrieved token in 'Authorization: Bearer <TOKEN>' header"
+    type: apiKey # actually apiKey is not correct type but 'bearer' type is not supported in swaggger v2.0
+    in: header
+    name: "Authorization"
+security:
+  - bearer_auth: []
+  - basic_auth: []
+paths:
+  /login:
+    get:
+      summary: "Generate or renew auth token. Requires HTTP-basic authorization."
+      description: ""
+      parameters:
+        - name: "token-lifetime"
+          in: "query"
+          description: "initial lifetime in seconds. Max value is 90 days. Default: 10 min"
+          required: false
+          type: "number"
+          format: "int32"
+      produces:
+      - "application/json"
+      responses:
+        "200":
+          description: ""
+          schema:
+            type: "object"
+            properties:
+              token:
+                type: "string"
+    post:
+      summary: "Generate or renew auth token. Requires username and password provided in request body"
+      description: "username and password parameters are required. They can be provided either in JSON either in x-www-formurlencoded format"
+      # swagger 2.0 does not allow describing a method that accepts multiple content-types
+      parameters:
+        - name: "token-lifetime"
+          in: "query"
+          description: "initial lifetime in seconds. Max value is 90 days. Default: 10 min"
+          required: false
+          type: "number"
+          format: "int32"
+      produces:
+      - "application/json"
+      responses:
+        "200":
+          description: ""
+          schema:
+            type: "object"
+            properties:
+              token:
+                type: "string"
+    delete:
+      summary: "Revoke token (logoff). Requires Bearer authorization provided"
+      description: ""
+      produces:
+        - "application/json"
+      responses:
+        "200":
+          description: "token revoked"
+  /status:
+    get:
+      summary: "Get information about rport server"
+      description: "show health status and server version"
+      produces:
+      - "application/json"
+      responses:
+        "200":
+          description: "success response"
+          schema:
+            type: "object"
+            properties:
+              version:
+                type: "string"
+              sessions_count:
+                type: "integer"
+  /sessions:
+    get:
+      summary: "List active client connections"
+      description: ""
+      produces:
+      - "application/json"
+      responses:
+        "200":
+          description: "success response"
+          schema:
+            items:
+              $ref: "#/definitions/Session"
+  /sessions/{session_id}/tunnels:
+    parameters:
+      - name: "session_id"
+        in: "path"
+        description: "unique session id retrieved previously"
+        required: true
+        type: "string"
+    put:
+      summary: "Request new tunnel for active client connection"
+      description: ""
+      produces:
+      - "application/json"
+      responses:
+        "200":
+          description: "success response"
+          schema:
+            allOf:
+              - $ref: "#/definitions/ApiResponse"
+              - type: "object"
+                properties:
+                  tunnel_id:
+                    type: "string"
+        "204":
+          description: "success response. Tunnel with such endpoints already exists"
+          schema:
+            items:
+              $ref: "#/definitions/ApiResponse"
+        "400":
+          description: "invalid parameters"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        "403":
+          description: "creating this tunnel is not allowed"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        "404":
+          description: "specified session does not exist or already terminated"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        "409":
+          description: "can't create requested tunnel. Probably port already busy"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+  /sessions/{session_id}/tunnels/{tunnel_id}:
+    parameters:
+      - name: "session_id"
+        in: "path"
+        description: "unique session id retrieved previously"
+        required: true
+        type: "string"
+      - name: "tunnel_id"
+        in: "path"
+        description: "unique tunnel id retrieved previously"
+        required: true
+        type: "string"
+    delete:
+      summary:  "Terminate specified tunnel"
+      description: ""
+      responses:
+        "200":
+          description: "tunnel terminated"
+          schema:
+            $ref: "#/definitions/ApiResponse"
+        "400":
+          description: "invalid parameters"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        "404":
+          description: "specified session or tunnel does not exist or already terminated"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+definitions:
+  Tunnel:
+    type: "object"
+    properties:
+      id:
+        type: "string"
+      lhost:
+        type: "string"
+        description: "server listens to this host"
+      lport:
+        type: "string"
+        description: "server listens to this port"
+      rhost:
+        type: "string"
+        description: "client proxies connection to this host"
+      rport:
+        type: "string"
+        description: "client proxies connection to this port"
+  Session:
+    type: "object"
+    properties:
+      id:
+        type: "string"
+      version:
+        type: "string"
+        description: "client version"
+      address:
+        type: "string"
+        description: "client address"
+      tunnels:
+        items:
+          $ref: "#/definitions/Tunnel"
+  ApiResponse:
+    type: "object"
+    properties:
+      success:
+        type: "integer"
+        format: "int32"
+  ErrorResponse:
+    type: "object"
+    properties:
+      error:
+        type: "string"

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/andrew-d/go-termutil v0.0.0-20150726205930-009166a695a2 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/andrew-d/go-termutil v0.0.0-20150726205930-009166a695a2 h1:axBiC50cNZOs7ygH5BgQp4N+aYrZ2DNpWZ1KG3VOSOM=
 github.com/andrew-d/go-termutil v0.0.0-20150726205930-009166a695a2/go.mod h1:jnzFpU88PccN/tPPhCpnNU8mZphvKxYM9lLNkd8e+os=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=

--- a/server/api.go
+++ b/server/api.go
@@ -116,7 +116,7 @@ func (al *APIListener) handleDeleteSessionTunnel(w http.ResponseWriter, req *htt
 
 	tunnelID, exists := vars["tunnel_id"]
 	if !exists || tunnelID == "" {
-		al.jsonErrorResponse(w, http.StatusBadRequest, al.Errorf("invalid session id supplied: %s", sessionID))
+		al.jsonErrorResponse(w, http.StatusBadRequest, al.Errorf("invalid tunnel id supplied: %s", sessionID))
 		return
 	}
 

--- a/server/api.go
+++ b/server/api.go
@@ -2,20 +2,44 @@ package chserver
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/gorilla/mux"
 
 	chshare "github.com/cloudradar-monitoring/rport/share"
 )
 
+func (al *APIListener) wrapWithAuthMiddleware(f http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ok := al.handleAuthorization(w, r)
+		if !ok {
+			return
+		}
+		f.ServeHTTP(w, r)
+	}
+}
+
 func (al *APIListener) initRouter() {
 	r := mux.NewRouter()
 	sub := r.PathPrefix("/api/v1").Subrouter()
+	sub.HandleFunc("/login", al.handleGetLogin).Methods(http.MethodGet)
 	sub.HandleFunc("/status", al.handleGetStatus).Methods(http.MethodGet)
 	sub.HandleFunc("/sessions", al.handleGetSessions).Methods(http.MethodGet)
 	sub.HandleFunc("/sessions/{session_id}/tunnels", al.handlePutSessionTunnel).Methods(http.MethodPut)
 	sub.HandleFunc("/sessions/{session_id}/tunnels/{tunnel_id}", al.handleDeleteSessionTunnel).Methods(http.MethodDelete)
+
+	// add authorization middleware
+	_ = sub.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		route.HandlerFunc(al.wrapWithAuthMiddleware(route.GetHandler()))
+		return nil
+	})
+	// all routes defined below will not require authorization
+
+	sub.HandleFunc("/login", al.handlePostLogin).Methods(http.MethodPost)
+	sub.HandleFunc("/login", al.handleDeleteLogin).Methods(http.MethodDelete)
 
 	al.router = r
 }
@@ -38,15 +62,138 @@ func (al *APIListener) jsonErrorResponse(w http.ResponseWriter, statusCode int, 
 	al.writeJSONResponse(w, statusCode, map[string]string{"error": err.Error()})
 }
 
+func (al *APIListener) handleGetLogin(w http.ResponseWriter, req *http.Request) {
+	lifetime, err := parseTokenLifetime(req)
+	if err != nil {
+		al.jsonErrorResponse(w, http.StatusBadRequest, err)
+		return
+	}
+
+	tokenStr, err := al.createAuthToken(lifetime)
+	if err != nil {
+		al.jsonErrorResponse(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	al.writeJSONResponse(w, http.StatusOK, map[string]string{"token": tokenStr})
+}
+
+func (al *APIListener) handlePostLogin(w http.ResponseWriter, req *http.Request) {
+	lifetime, err := parseTokenLifetime(req)
+	if err != nil {
+		al.jsonErrorResponse(w, http.StatusBadRequest, err)
+		return
+	}
+
+	user, pwd, err := parseLoginPostRequestBody(req)
+	if err != nil {
+		al.jsonErrorResponse(w, http.StatusBadRequest, fmt.Errorf("can't parse request body: %s", err))
+		return
+	}
+
+	if !al.validateUserPasswordPair(user, pwd) {
+		al.jsonErrorResponse(w, http.StatusUnauthorized, fmt.Errorf("unauthorized"))
+		return
+	}
+
+	tokenStr, err := al.createAuthToken(lifetime)
+	if err != nil {
+		al.jsonErrorResponse(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	al.writeJSONResponse(w, http.StatusOK, map[string]string{"token": tokenStr})
+}
+
+func parseLoginPostRequestBody(req *http.Request) (string, string, error) {
+	reqContentType := req.Header.Get("Content-Type")
+	if reqContentType == "application/x-www-form-urlencoded" {
+		err := req.ParseForm()
+		if err != nil {
+			return "", "", err
+		}
+		return req.PostForm.Get("username"), req.PostForm.Get("password"), nil
+	}
+	if reqContentType == "application/json" {
+		type loginReq struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+		}
+		var params loginReq
+		err := json.NewDecoder(req.Body).Decode(&params)
+		if err != nil {
+			return "", "", err
+		}
+		return params.Username, params.Password, nil
+	}
+	return "", "", fmt.Errorf("unsupported content type")
+}
+
+func parseTokenLifetime(req *http.Request) (time.Duration, error) {
+	lifetimeStr := req.URL.Query().Get("token-lifetime")
+	if lifetimeStr == "" {
+		lifetimeStr = "0"
+	}
+	lifetime, err := strconv.ParseInt(lifetimeStr, 10, 0)
+	if err != nil {
+		return 0, fmt.Errorf("invalid token-lifetime : %s", err)
+	}
+	result := time.Duration(lifetime) * time.Second
+	if result > maxTokenLifetime {
+		return 0, fmt.Errorf("requested token lifetime exceeds max allowed %d", maxTokenLifetime/time.Second)
+	}
+	if result <= 0 {
+		result = defaultTokenLifetime
+	}
+	return result, nil
+}
+
+func (al *APIListener) handleDeleteLogin(w http.ResponseWriter, req *http.Request) {
+	token, tokenProvided := getBearerToken(req)
+	if token == "" || !tokenProvided {
+		al.jsonErrorResponse(w, http.StatusBadRequest, fmt.Errorf("authorization Bearer token required"))
+		return
+	}
+
+	valid, apiSession, err := al.validateBearerToken(token)
+	if err != nil {
+		al.jsonErrorResponse(w, http.StatusInternalServerError, err)
+		return
+	}
+	if !valid {
+		al.jsonErrorResponse(w, http.StatusBadRequest, fmt.Errorf("token is invalid or expired"))
+		return
+	}
+
+	err = al.apiSessionRepo.Delete(apiSession)
+	if err != nil {
+		al.jsonErrorResponse(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	response := map[string]interface{}{"success": 1}
+	al.writeJSONResponse(w, http.StatusOK, response)
+}
+
 func (al *APIListener) handleGetStatus(w http.ResponseWriter, req *http.Request) {
+	count, err := al.sessionRepo.Count()
+	if err != nil {
+		al.jsonErrorResponse(w, http.StatusInternalServerError, err)
+		return
+	}
 	al.writeJSONResponse(w, http.StatusOK, map[string]interface{}{
 		"version":        chshare.BuildVersion,
-		"sessions_count": al.sessionRepo.Count(),
+		"sessions_count": count,
 	})
 }
 
 func (al *APIListener) handleGetSessions(w http.ResponseWriter, req *http.Request) {
-	al.writeJSONResponse(w, http.StatusOK, al.sessionRepo.GetAll())
+	clientSessions, err := al.sessionRepo.GetAll()
+	if err != nil {
+		al.jsonErrorResponse(w, http.StatusInternalServerError, err)
+		return
+	}
+	al.writeJSONResponse(w, http.StatusOK, clientSessions)
 }
 
 func (al *APIListener) handlePutSessionTunnel(w http.ResponseWriter, req *http.Request) {
@@ -57,7 +204,11 @@ func (al *APIListener) handlePutSessionTunnel(w http.ResponseWriter, req *http.R
 		return
 	}
 
-	session := al.sessionRepo.FindOne(sessionID)
+	session, err := al.sessionRepo.FindOne(sessionID)
+	if err != nil {
+		al.jsonErrorResponse(w, http.StatusInternalServerError, err)
+		return
+	}
 	if session == nil {
 		al.jsonErrorResponse(w, http.StatusNotFound, al.Errorf("session not found"))
 		return
@@ -108,7 +259,11 @@ func (al *APIListener) handleDeleteSessionTunnel(w http.ResponseWriter, req *htt
 		return
 	}
 
-	session := al.sessionRepo.FindOne(sessionID)
+	session, err := al.sessionRepo.FindOne(sessionID)
+	if err != nil {
+		al.jsonErrorResponse(w, http.StatusInternalServerError, err)
+		return
+	}
 	if session == nil {
 		al.jsonErrorResponse(w, http.StatusNotFound, al.Errorf("session not found"))
 		return

--- a/server/api_listener.go
+++ b/server/api_listener.go
@@ -1,7 +1,10 @@
 package chserver
 
 import (
+	"crypto/subtle"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/jpillora/requestlog"
@@ -12,23 +15,36 @@ import (
 type APIListener struct {
 	*chshare.Logger
 
-	sessionRepo *SessionRepository
-	router      *mux.Router
-	httpServer  *chshare.HTTPServer
+	authUser       string
+	authPassword   string
+	jwtSecret      string
+	sessionRepo    *SessionRepository
+	apiSessionRepo *APISessionRepository
+	router         *mux.Router
+	httpServer     *chshare.HTTPServer
 }
 
-func NewAPIListener(config *Config, s *SessionRepository) *APIListener {
+func NewAPIListener(config *Config, s *SessionRepository) (*APIListener, error) {
+	authUser, authPassword, err := parseHTTPAuthStr(config.APIAuth)
+	if err != nil {
+		return nil, err
+	}
+
 	a := &APIListener{
-		Logger:      chshare.NewLogger("api-listener"),
-		sessionRepo: s,
-		httpServer:  chshare.NewHTTPServer(),
+		Logger:         chshare.NewLogger("api-listener"),
+		authUser:       authUser,
+		authPassword:   authPassword,
+		jwtSecret:      config.APIJWTSecret,
+		sessionRepo:    s,
+		apiSessionRepo: NewAPISessionRepository(),
+		httpServer:     chshare.NewHTTPServer(),
 	}
 	a.Info = true
 	a.Debug = config.Verbose
 
 	a.initRouter()
 
-	return a
+	return a, nil
 }
 
 func (al *APIListener) Start(addr string) error {
@@ -68,4 +84,66 @@ func (al *APIListener) handleAPIRequest(w http.ResponseWriter, r *http.Request) 
 	}
 	w.WriteHeader(404)
 	_, _ = w.Write([]byte{})
+}
+
+func (al *APIListener) handleAuthorization(w http.ResponseWriter, r *http.Request) bool {
+	if al.authUser == "" || al.authPassword == "" {
+		return true
+	}
+
+	basicUser, basicPwd, basicAuthProvided := r.BasicAuth()
+	bearerToken, bearerAuthProvided := getBearerToken(r)
+
+	var err error
+	var authorized bool
+	if basicAuthProvided {
+		authorized = al.validateUserPasswordPair(basicUser, basicPwd)
+	} else if bearerAuthProvided {
+		authorized, err = al.handleBearerToken(bearerToken)
+		if err != nil {
+			al.jsonErrorResponse(w, http.StatusInternalServerError, err)
+			return false
+		}
+	}
+
+	if !authorized {
+		w.Header().Set("WWW-Authenticate", `Basic realm="rportd-api"`)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte{})
+	}
+
+	return authorized
+}
+
+func (al *APIListener) handleBearerToken(bearerToken string) (bool, error) {
+	authorized, apiSession, err := al.validateBearerToken(bearerToken)
+	if err != nil {
+		return false, err
+	}
+	if authorized {
+		err = al.increaseSessionLifetime(apiSession)
+		if err != nil {
+			return true, err
+		}
+	}
+	return authorized, nil
+}
+
+func (al *APIListener) validateUserPasswordPair(basicUser, basicPwd string) bool {
+	return subtle.ConstantTimeCompare([]byte(basicUser), []byte(al.authUser)) == 1 &&
+		subtle.ConstantTimeCompare([]byte(basicPwd), []byte(al.authPassword)) == 1
+}
+
+// parseHTTPAuthStr parses <user>:<password> string, returns (user, password, nil) or an error
+func parseHTTPAuthStr(basicAuth string) (string, string, error) {
+	if basicAuth == "" {
+		return "", "", nil
+	}
+
+	parts := strings.Split(basicAuth, ":")
+	if len(parts) != 2 || len(parts[0]) == 0 || len(parts[1]) == 0 {
+		return "", "", fmt.Errorf("can't parse basic-auth string")
+	}
+
+	return parts[0], parts[1], nil
 }

--- a/server/api_session.go
+++ b/server/api_session.go
@@ -1,0 +1,36 @@
+package chserver
+
+import "time"
+
+type APISession struct {
+	Token     string
+	ExpiresAt time.Time
+}
+
+type APISessionRepository struct {
+	sessions map[string]*APISession
+}
+
+func NewAPISessionRepository() *APISessionRepository {
+	return &APISessionRepository{
+		sessions: make(map[string]*APISession),
+	}
+}
+
+func (r *APISessionRepository) Save(session *APISession) error {
+	r.sessions[session.Token] = session
+	return nil
+}
+
+func (r *APISessionRepository) Delete(session *APISession) error {
+	delete(r.sessions, session.Token)
+	return nil
+}
+
+func (r *APISessionRepository) FindOne(id string) (*APISession, error) {
+	c, exists := r.sessions[id]
+	if !exists {
+		return nil, nil
+	}
+	return c, nil
+}

--- a/server/bearer_auth.go
+++ b/server/bearer_auth.go
@@ -1,0 +1,74 @@
+package chserver
+
+import (
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+const (
+	maxTokenLifetime     = 90 * 24 * time.Hour
+	defaultTokenLifetime = 10 * time.Minute
+)
+
+func (al *APIListener) createAuthToken(lifetime time.Duration) (string, error) {
+	claims := jwt.StandardClaims{
+		Id: strconv.FormatUint(rand.Uint64(), 10),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenStr, err := token.SignedString([]byte(al.jwtSecret))
+	if err != nil {
+		return "", err
+	}
+
+	expiresAt := time.Now().Add(lifetime)
+	err = al.apiSessionRepo.Save(&APISession{tokenStr, expiresAt})
+	if err != nil {
+		return "", err
+	}
+
+	return tokenStr, nil
+}
+
+func (al *APIListener) increaseSessionLifetime(s *APISession) error {
+	newExpirationDate := s.ExpiresAt.Add(defaultTokenLifetime)
+	if time.Now().After(s.ExpiresAt) {
+		newExpirationDate = time.Now().Add(defaultTokenLifetime)
+	}
+	s.ExpiresAt = newExpirationDate
+	return al.apiSessionRepo.Save(s)
+}
+
+func (al *APIListener) validateBearerToken(tokenStr string) (bool, *APISession, error) {
+	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (i interface{}, err error) {
+		return []byte(al.jwtSecret), nil
+	})
+	if err != nil || !token.Valid {
+		return false, nil, nil
+	}
+
+	apiSession, err := al.apiSessionRepo.FindOne(tokenStr)
+	if err != nil || apiSession == nil {
+		return false, apiSession, err
+	}
+
+	return apiSession.ExpiresAt.After(time.Now()), apiSession, nil
+}
+
+func getBearerToken(req *http.Request) (string, bool) {
+	auth := req.Header.Get("Authorization")
+	if auth == "" {
+		return "", false
+	}
+	const prefix = "Bearer "
+	// Case insensitive prefix match.
+	if len(auth) < len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) {
+		return "", false
+	}
+
+	return auth[len(prefix):], true
+}

--- a/server/server.go
+++ b/server/server.go
@@ -6,11 +6,13 @@ import (
 
 // Config is the configuration for the rport service
 type Config struct {
-	KeySeed  string
-	AuthFile string
-	Auth     string
-	Proxy    string
-	Verbose  bool
+	KeySeed      string
+	AuthFile     string
+	Auth         string
+	Proxy        string
+	Verbose      bool
+	APIAuth      string
+	APIJWTSecret string
 }
 
 // Server represents a rport service
@@ -31,7 +33,10 @@ func NewServer(config *Config) (*Server, error) {
 		return nil, err
 	}
 
-	s.apiListener = NewAPIListener(config, sessionRepo)
+	s.apiListener, err = NewAPIListener(config, sessionRepo)
+	if err != nil {
+		return nil, err
+	}
 
 	return s, nil
 }

--- a/server/session_repository.go
+++ b/server/session_repository.go
@@ -10,30 +10,32 @@ func NewSessionRepository() *SessionRepository {
 	}
 }
 
-func (s *SessionRepository) Add(session *ClientSession) {
+func (s *SessionRepository) Save(session *ClientSession) error {
 	s.sessions[session.ID] = session
+	return nil
 }
 
-func (s *SessionRepository) Delete(session *ClientSession) {
+func (s *SessionRepository) Delete(session *ClientSession) error {
 	delete(s.sessions, session.ID)
+	return nil
 }
 
-func (s *SessionRepository) Count() int {
-	return len(s.sessions)
+func (s *SessionRepository) Count() (int, error) {
+	return len(s.sessions), nil
 }
 
-func (s *SessionRepository) FindOne(id string) *ClientSession {
+func (s *SessionRepository) FindOne(id string) (*ClientSession, error) {
 	c, exists := s.sessions[id]
 	if !exists {
-		return nil
+		return nil, nil
 	}
-	return c
+	return c, nil
 }
 
-func (s *SessionRepository) GetAll() []*ClientSession {
+func (s *SessionRepository) GetAll() ([]*ClientSession, error) {
 	var result = make([]*ClientSession, 0)
 	for _, c := range s.sessions {
 		result = append(result, c)
 	}
-	return result
+	return result, nil
 }


### PR DESCRIPTION
DEV-1611

- API documentation added (swagger 2.0), see file api-doc.yml
- new CLI options --api-auth and --api-jwt-secret
- allow HTTP-basic authorization
- allow Bearer authorization using JWT tokens
- information about token expiration stored in-memory, meaning server restart will shutdown active api user sessions.  Later we will add support for persistent storage. For this purpose public methods of storage managers (APISessionStorage and ClientSessionStorage) were unified.
- initial token expiration still can be specified in /login requests with token-lifetime option. Max value is 90 days (in seconds). Default: 10 min.
- each request with `Authorization: Bearer XXX` header increases token lifetime (+10 min). Token does not hold expiration date meaning it remains unchanged.
