### PR TITLE
Update golangci linter config to honor gomod-vendored dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
     <<: *docker_job
     steps:
       - <<: *workspace
+      - run: go mod vendor
       - run: golangci-lint -c .golangci.yml run
 
   test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,8 @@ run:
   # include test files or not, default is true
   tests: true
 
+  modules-download-mode: vendor
+
 output:
   # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
   format: colored-line-number


### PR DESCRIPTION
Now `make docker-golangci-lint` executes really quick when running locally because all the dependencies already in-place.
CI job duration also shortened from ~45 sec to ~8sec