### PR TITLE
Allow logging to a file and specifying log verbosity (error, info, debug)

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -54,7 +54,7 @@ func (al *APIListener) writeJSONResponse(w http.ResponseWriter, statusCode int, 
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(statusCode)
 	if _, err := w.Write(b); err != nil {
-		al.Infof("error writing response: %s", err)
+		al.Errorf("error writing response: %s", err)
 	}
 }
 
@@ -200,7 +200,7 @@ func (al *APIListener) handlePutSessionTunnel(w http.ResponseWriter, req *http.R
 	vars := mux.Vars(req)
 	sessionID, exists := vars["session_id"]
 	if !exists || sessionID == "" {
-		al.jsonErrorResponse(w, http.StatusBadRequest, al.Errorf("invalid session id supplied: %s", sessionID))
+		al.jsonErrorResponse(w, http.StatusBadRequest, al.FormatError("invalid session id supplied: %s", sessionID))
 		return
 	}
 
@@ -210,7 +210,7 @@ func (al *APIListener) handlePutSessionTunnel(w http.ResponseWriter, req *http.R
 		return
 	}
 	if session == nil {
-		al.jsonErrorResponse(w, http.StatusNotFound, al.Errorf("session not found"))
+		al.jsonErrorResponse(w, http.StatusNotFound, al.FormatError("session not found"))
 		return
 	}
 
@@ -218,13 +218,13 @@ func (al *APIListener) handlePutSessionTunnel(w http.ResponseWriter, req *http.R
 	remoteAddr := req.URL.Query().Get("remote")
 	remote, err := chshare.DecodeRemote(localAddr + ":" + remoteAddr)
 	if err != nil {
-		al.jsonErrorResponse(w, http.StatusBadRequest, al.Errorf("invalid request: %s", err))
+		al.jsonErrorResponse(w, http.StatusBadRequest, al.FormatError("invalid request: %s", err))
 		return
 	}
 
 	// check user permissions
 	if session.User != nil && !session.User.HasAccess(remote) {
-		al.jsonErrorResponse(w, http.StatusForbidden, al.Errorf("access is not allowed for current session"))
+		al.jsonErrorResponse(w, http.StatusForbidden, al.FormatError("access is not allowed for current session"))
 		return
 	}
 
@@ -243,7 +243,7 @@ func (al *APIListener) handlePutSessionTunnel(w http.ResponseWriter, req *http.R
 
 	tunnelID, err := session.StartRemoteTunnel(remote)
 	if err != nil {
-		al.jsonErrorResponse(w, http.StatusConflict, al.Errorf("can't create tunnel: %s", err))
+		al.jsonErrorResponse(w, http.StatusConflict, al.FormatError("can't create tunnel: %s", err))
 		return
 	}
 	response["tunnel_id"] = tunnelID
@@ -255,7 +255,7 @@ func (al *APIListener) handleDeleteSessionTunnel(w http.ResponseWriter, req *htt
 	vars := mux.Vars(req)
 	sessionID, exists := vars["session_id"]
 	if !exists || sessionID == "" {
-		al.jsonErrorResponse(w, http.StatusBadRequest, al.Errorf("invalid session id supplied: %s", sessionID))
+		al.jsonErrorResponse(w, http.StatusBadRequest, al.FormatError("invalid session id supplied: %s", sessionID))
 		return
 	}
 
@@ -265,13 +265,13 @@ func (al *APIListener) handleDeleteSessionTunnel(w http.ResponseWriter, req *htt
 		return
 	}
 	if session == nil {
-		al.jsonErrorResponse(w, http.StatusNotFound, al.Errorf("session not found"))
+		al.jsonErrorResponse(w, http.StatusNotFound, al.FormatError("session not found"))
 		return
 	}
 
 	tunnelID, exists := vars["tunnel_id"]
 	if !exists || tunnelID == "" {
-		al.jsonErrorResponse(w, http.StatusBadRequest, al.Errorf("invalid tunnel id supplied: %s", sessionID))
+		al.jsonErrorResponse(w, http.StatusBadRequest, al.FormatError("invalid tunnel id supplied: %s", sessionID))
 		return
 	}
 
@@ -281,7 +281,7 @@ func (al *APIListener) handleDeleteSessionTunnel(w http.ResponseWriter, req *htt
 
 	tunnel := session.FindTunnel(tunnelID)
 	if tunnel == nil {
-		al.jsonErrorResponse(w, http.StatusNotFound, al.Errorf("tunnel not found"))
+		al.jsonErrorResponse(w, http.StatusNotFound, al.FormatError("tunnel not found"))
 		return
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,12 @@
 package chserver
 
 import (
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/jpillora/requestlog"
+
 	chshare "github.com/cloudradar-monitoring/rport/share"
 )
 
@@ -10,10 +16,20 @@ type Config struct {
 	AuthFile     string
 	Auth         string
 	Proxy        string
-	Verbose      bool
 	APIAuth      string
 	APIJWTSecret string
 	DocRoot      string
+	LogOutput    *os.File
+	LogLevel     chshare.LogLevel
+}
+
+func (c *Config) InitRequestLogOptions() *requestlog.Options {
+	o := requestlog.DefaultOptions
+	o.Writer = c.LogOutput
+	o.Filter = func(r *http.Request, code int, duration time.Duration, size int64) bool {
+		return c.LogLevel == chshare.LogLevelInfo || c.LogLevel == chshare.LogLevelDebug
+	}
+	return &o
 }
 
 // Server represents a rport service

--- a/server/tunnel.go
+++ b/server/tunnel.go
@@ -80,7 +80,7 @@ func (t *Tunnel) listen(ctx context.Context, l net.Listener) {
 			case <-ctx.Done():
 				//listener closed
 			default:
-				t.Infof("Accept error: %s", err)
+				t.Errorf("Accept error: %s", err)
 			}
 			close(done)
 			return
@@ -102,7 +102,7 @@ func (t *Tunnel) accept(src io.ReadWriteCloser) {
 	//ssh request for tcp connection for this proxy's remote
 	dst, reqs, err := t.sshConn.OpenChannel("rport", []byte(t.Remote.Remote()))
 	if err != nil {
-		l.Infof("Stream error: %s", err)
+		l.Errorf("Stream error: %s", err)
 		return
 	}
 	go ssh.DiscardRequests(reqs)

--- a/share/conn_ws.go
+++ b/share/conn_ws.go
@@ -1,7 +1,6 @@
 package chshare
 
 import (
-	"log"
 	"net"
 	"time"
 
@@ -20,23 +19,19 @@ func NewWebSocketConn(websocketConn *websocket.Conn) net.Conn {
 	return &c
 }
 
-//Read is not threadsafe though thats okay since there
+//Read is not thread-safe though that's okay since there
 //should never be more than one reader
 func (c *wsConn) Read(dst []byte) (int, error) {
 	ldst := len(dst)
 	//use buffer or read new message
 	var src []byte
-	if l := len(c.buff); l > 0 {
+	if len(c.buff) > 0 {
 		src = c.buff
 		c.buff = nil
-	} else {
-		t, msg, err := c.Conn.ReadMessage()
-		if err != nil {
-			return 0, err
-		} else if t != websocket.BinaryMessage {
-			log.Printf("<WARNING> non-binary msg")
-		}
+	} else if _, msg, err := c.Conn.ReadMessage(); err == nil {
 		src = msg
+	} else {
+		return 0, err
 	}
 	//copy src->dest
 	var n int

--- a/share/users.go
+++ b/share/users.go
@@ -103,7 +103,7 @@ func (u *UserIndex) addWatchEvents() error {
 				continue
 			}
 			if err := u.loadUserIndex(); err != nil {
-				u.Infof("Failed to reload the users configuration: %s", err)
+				u.Errorf("Failed to reload the users configuration: %s", err)
 			} else {
 				u.Debugf("Users configuration successfully reloaded from: %s", u.configFile)
 			}


### PR DESCRIPTION
DEV-1634

I've also renamed the `Logger.Errorf` function to `FormatError`. New `Errorf` function now prints a message to a log, similarly to `logrus.Logger` interface we have in cagent and frontman.