### PR TITLE
Implement random server port assignment when the 'local' part is not specified (either on CLI or API request)

### DIFF
--- a/api-doc.yml
+++ b/api-doc.yml
@@ -105,7 +105,7 @@ paths:
         type: "string"
       - name: "local"
         in: "query"
-        description: "server address to use for a new tunnel, e.g. '3390' or '0.0.0.0:3390'"
+        description: "server address to use for a new tunnel, e.g. '3390' or '0.0.0.0:3390'. If local is not specified, a random server port will be assigned automatically"
         required: false
         type: "string"
       - name: "remote"

--- a/cmd/rport/main.go
+++ b/cmd/rport/main.go
@@ -47,10 +47,13 @@ var clientHelp = `
   which come in the form:
 
     <local-interface>:<local-port>:<remote-host>:<remote-port>
+    or
+    <remote-host>:<remote-port>
 
   which does reverse port forwarding, sharing <remote-host>:<remote-port>
   from the client to the server's <local-interface>:<local-port>.
-  Only IPv4 tunnels are supported.
+  If local part is omitted, a randomly chosen server port will be assigned. 
+  Only IPv4 addresses are supported.
 
   Examples:
 
@@ -58,7 +61,7 @@ var clientHelp = `
     forwards port 2222 of the server to port 22 of the client
 
     ./rport <SERVER>:<PORT> 3000 
-    forwards port 3000 of the server to port 3000 of the client
+    forwards randomly-assigned free port of the server to port 3000 of the client
 
     ./rport <SERVER>:<PORT> example.com:3000
     forwards port 3000 of the server to port 3000 of example.com
@@ -74,7 +77,7 @@ var clientHelp = `
     originating the connection from the client
 
     ./rport "[2a01:4f9:c010:b278::1]:9999" 3389
-    using IPv6 server address. Forwards port 3389 of the server
+    using IPv6 server address. Forwards randomly-assigned free port of the server
     to port 3389 of the client
 
   Options:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/andrew-d/go-termutil v0.0.0-20150726205930-009166a695a2 // indirect
+	github.com/deckarep/golang-set v1.7.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-ole/go-ole v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/andrew-d/go-termutil v0.0.0-20150726205930-009166a695a2 h1:axBiC50cNZ
 github.com/andrew-d/go-termutil v0.0.0-20150726205930-009166a695a2/go.mod h1:jnzFpU88PccN/tPPhCpnNU8mZphvKxYM9lLNkd8e+os=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
+github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=

--- a/server/client_session.go
+++ b/server/client_session.go
@@ -55,7 +55,7 @@ func (c *ClientSession) findTunnelByRemote(r *chshare.Remote) *Tunnel {
 	return nil
 }
 
-func (c *ClientSession) StartRemoteTunnel(r *chshare.Remote) (*Tunnel, error) {
+func (c *ClientSession) StartTunnel(r *chshare.Remote) (*Tunnel, error) {
 	t := c.findTunnelByRemote(r)
 	if t != nil {
 		return t, nil

--- a/server/ports/port_distributor.go
+++ b/server/ports/port_distributor.go
@@ -1,0 +1,64 @@
+package ports
+
+import (
+	"fmt"
+	"math"
+
+	mapset "github.com/deckarep/golang-set"
+	"github.com/shirou/gopsutil/net"
+
+	chshare "github.com/cloudradar-monitoring/rport/share"
+)
+
+type PortDistributor struct {
+	allowedPorts mapset.Set
+	portsPool    mapset.Set
+}
+
+func NewPortDistributor(excludedPorts mapset.Set) *PortDistributor {
+	return &PortDistributor{
+		allowedPorts: chshare.SetFromRange(1, math.MaxUint16).Difference(excludedPorts),
+	}
+}
+
+func (d *PortDistributor) GetRandomPort() (int, error) {
+	if d.portsPool == nil {
+		err := d.Refresh()
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	port := d.portsPool.Pop()
+	if port == nil {
+		return 0, fmt.Errorf("no ports available")
+	}
+	return port.(int), nil
+}
+
+func (d *PortDistributor) Refresh() error {
+	busyPorts, err := listBusyPorts()
+	if err != nil {
+		return err
+	}
+
+	d.portsPool = d.allowedPorts.Difference(busyPorts)
+	return nil
+}
+
+func listBusyPorts() (mapset.Set, error) {
+	result := mapset.NewThreadUnsafeSet()
+	connections, err := net.Connections("all")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, c := range connections {
+		isActive := c.Status == "LISTEN" || c.Status == "NONE" || c.Status == ""
+		if isActive && c.Laddr.Port != 0 {
+			result.Add(int(c.Laddr.Port))
+		}
+	}
+
+	return result, nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -5,22 +5,25 @@ import (
 	"os"
 	"time"
 
+	mapset "github.com/deckarep/golang-set"
 	"github.com/jpillora/requestlog"
 
+	"github.com/cloudradar-monitoring/rport/server/ports"
 	chshare "github.com/cloudradar-monitoring/rport/share"
 )
 
 // Config is the configuration for the rport service
 type Config struct {
-	KeySeed      string
-	AuthFile     string
-	Auth         string
-	Proxy        string
-	APIAuth      string
-	APIJWTSecret string
-	DocRoot      string
-	LogOutput    *os.File
-	LogLevel     chshare.LogLevel
+	KeySeed       string
+	AuthFile      string
+	Auth          string
+	Proxy         string
+	APIAuth       string
+	APIJWTSecret  string
+	DocRoot       string
+	LogOutput     *os.File
+	LogLevel      chshare.LogLevel
+	ExcludedPorts mapset.Set
 }
 
 func (c *Config) InitRequestLogOptions() *requestlog.Options {
@@ -43,7 +46,9 @@ func NewServer(config *Config) (*Server, error) {
 	s := &Server{}
 
 	var err error
-	sessionService := NewSessionService()
+	sessionService := NewSessionService(
+		ports.NewPortDistributor(config.ExcludedPorts),
+	)
 
 	s.clientListener, err = NewClientListener(config, sessionService)
 	if err != nil {

--- a/server/session_service.go
+++ b/server/session_service.go
@@ -2,19 +2,23 @@ package chserver
 
 import (
 	"context"
+	"strconv"
 
 	"golang.org/x/crypto/ssh"
 
+	"github.com/cloudradar-monitoring/rport/server/ports"
 	chshare "github.com/cloudradar-monitoring/rport/share"
 )
 
 type SessionService struct {
-	repo *ClientSessionRepository
+	repo            *ClientSessionRepository
+	portDistributor *ports.PortDistributor
 }
 
-func NewSessionService() *SessionService {
+func NewSessionService(portDistributor *ports.PortDistributor) *SessionService {
 	return &SessionService{
-		repo: NewSessionRepository(),
+		repo:            NewSessionRepository(),
+		portDistributor: portDistributor,
 	}
 }
 
@@ -51,18 +55,40 @@ func (s *SessionService) StartClientSession(
 		Logger:     clog,
 	}
 
-	for _, r := range cfg.Remotes {
-		_, err := session.StartRemoteTunnel(r)
-		if err != nil {
-			return nil, err
-		}
-	}
+	_, err := s.StartSessionTunnels(session, cfg.Remotes)
 
-	err := s.repo.Save(session)
+	err = s.repo.Save(session)
 	if err != nil {
 		return nil, err
 	}
 	return session, nil
+}
+
+// StartSessionTunnels returns a new tunnel for each requested remote or nil if error occurred
+func (s *SessionService) StartSessionTunnels(session *ClientSession, remotes []*chshare.Remote) ([]*Tunnel, error) {
+	err := s.portDistributor.Refresh()
+	if err != nil {
+		return nil, err
+	}
+
+	tunnels := make([]*Tunnel, 0, len(remotes))
+	for _, remote := range remotes {
+		if !remote.IsLocalSpecified() {
+			port, err := s.portDistributor.GetRandomPort()
+			if err != nil {
+				return nil, err
+			}
+			remote.LocalPort = strconv.Itoa(port)
+			remote.LocalHost = "0.0.0.0"
+		}
+
+		t, err := session.StartTunnel(remote)
+		if err != nil {
+			return nil, err
+		}
+		tunnels = append(tunnels, t)
+	}
+	return tunnels, nil
 }
 
 func (s *SessionService) Terminate(session *ClientSession) error {

--- a/share/remote.go
+++ b/share/remote.go
@@ -40,7 +40,6 @@ func DecodeRemote(s string) (*Remote, error) {
 		if isPort(p) {
 			if r.RemotePort == "" {
 				r.RemotePort = p
-				r.LocalPort = p
 			} else {
 				r.LocalPort = p
 			}
@@ -58,7 +57,7 @@ func DecodeRemote(s string) (*Remote, error) {
 			r.LocalHost = p
 		}
 	}
-	if r.LocalHost == "" {
+	if r.LocalHost == "" && r.LocalPort != "" {
 		r.LocalHost = "0.0.0.0"
 	}
 	if r.RemoteHost == "" {
@@ -89,4 +88,8 @@ func (r *Remote) Remote() string {
 
 func (r *Remote) Equals(other *Remote) bool {
 	return r.String() == other.String()
+}
+
+func (r *Remote) IsLocalSpecified() bool {
+	return r.LocalHost != "" && r.LocalPort != ""
 }

--- a/share/sets.go
+++ b/share/sets.go
@@ -1,0 +1,13 @@
+package chshare
+
+import (
+	mapset "github.com/deckarep/golang-set"
+)
+
+func SetFromRange(start, end int) mapset.Set {
+	s := mapset.NewThreadUnsafeSet()
+	for i := 0; i <= end-start; i++ {
+		s.Add(start + i)
+	}
+	return s
+}


### PR DESCRIPTION
New CLI option --exclude-ports added to allow server administrators to specify ports forbidden to use

DEV-1650