### PR TITLE
Refactoring of client configuration options

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -19,14 +19,16 @@ func TestCustomHeaders(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("Foo", "Bar")
 	config := Config{
-		Fingerprint:      "",
-		Auth:             "",
-		KeepAlive:        time.Second,
-		MaxRetryCount:    0,
-		MaxRetryInterval: time.Second,
-		Server:           server.URL,
-		Remotes:          []string{"192.168.0.5:3000:google.com:80"},
-		Headers:          headers,
+		Fingerprint: "",
+		Auth:        "",
+		Connection: ConnectionOptions{
+			KeepAlive:        time.Second,
+			MaxRetryCount:    0,
+			MaxRetryInterval: time.Second,
+			Headers:          headers,
+		},
+		Server:  server.URL,
+		Remotes: []string{"192.168.0.5:3000:google.com:80"},
 	}
 	c, err := NewClient(&config)
 	if err != nil {

--- a/cmd/rport/main.go
+++ b/cmd/rport/main.go
@@ -139,14 +139,14 @@ var clientHelp = `
 `
 
 func main() {
-	config := chclient.Config{Headers: http.Header{}, LogOutput: os.Stdout}
+	config := chclient.Config{Connection: chclient.ConnectionOptions{Headers: http.Header{}}, LogOutput: os.Stdout}
 	flag.StringVar(&config.Fingerprint, "fingerprint", "", "")
 	flag.StringVar(&config.Auth, "auth", "", "")
-	flag.DurationVar(&config.KeepAlive, "keepalive", 0, "")
-	flag.IntVar(&config.MaxRetryCount, "max-retry-count", -1, "")
-	flag.DurationVar(&config.MaxRetryInterval, "max-retry-interval", 0, "")
+	flag.DurationVar(&config.Connection.KeepAlive, "keepalive", 0, "")
+	flag.IntVar(&config.Connection.MaxRetryCount, "max-retry-count", -1, "")
+	flag.DurationVar(&config.Connection.MaxRetryInterval, "max-retry-interval", 0, "")
 	flag.StringVar(&config.Proxy, "proxy", "", "")
-	flag.Var(&headerFlags{config.Headers}, "header", "")
+	flag.Var(&headerFlags{config.Connection.Headers}, "header", "")
 	flag.StringVar(&config.ID, "id", "", "")
 	flag.StringVar(&config.Name, "name", "", "")
 	flag.Var(&config.Tags, "tag", "")
@@ -179,7 +179,7 @@ func main() {
 	}
 	//move hostname onto headers
 	if *hostname != "" {
-		config.Headers.Set("Host", *hostname)
+		config.Connection.Headers.Set("Host", *hostname)
 	}
 
 	config.LogLevel = tryParseLogLevel(*logLevelStr)

--- a/server/session_service.go
+++ b/server/session_service.go
@@ -36,17 +36,17 @@ func (s *SessionService) GetAll() ([]*ClientSession, error) {
 
 func (s *SessionService) StartClientSession(
 	ctx context.Context, sid string, sshConn ssh.Conn,
-	cfg *chshare.Config, user *chshare.User, clog *chshare.Logger,
+	req *chshare.ConnectionRequest, user *chshare.User, clog *chshare.Logger,
 ) (*ClientSession, error) {
 	session := &ClientSession{
 		ID:         sid,
-		Name:       cfg.Name,
-		Tags:       cfg.Tags,
-		OS:         cfg.OS,
-		Hostname:   cfg.Hostname,
-		Version:    cfg.Version,
-		IPv4:       cfg.IPv4,
-		IPv6:       cfg.IPv6,
+		Name:       req.Name,
+		Tags:       req.Tags,
+		OS:         req.OS,
+		Hostname:   req.Hostname,
+		Version:    req.Version,
+		IPv4:       req.IPv4,
+		IPv6:       req.IPv6,
 		Address:    sshConn.RemoteAddr().String(),
 		Tunnels:    make([]*Tunnel, 0),
 		Connection: sshConn,
@@ -55,7 +55,7 @@ func (s *SessionService) StartClientSession(
 		Logger:     clog,
 	}
 
-	_, err := s.StartSessionTunnels(session, cfg.Remotes)
+	_, err := s.StartSessionTunnels(session, req.Remotes)
 	if err != nil {
 		return nil, err
 	}

--- a/share/protocol.go
+++ b/share/protocol.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 )
 
-type Config struct {
+// ConnectionRequest represents configuration options when initiating client-server connection
+type ConnectionRequest struct {
 	Version  string
 	ID       string
 	Name     string
@@ -17,8 +18,8 @@ type Config struct {
 	Remotes  []*Remote
 }
 
-func DecodeConfig(b []byte) (*Config, error) {
-	c := &Config{}
+func DecodeConnectionRequest(b []byte) (*ConnectionRequest, error) {
+	c := &ConnectionRequest{}
 	err := json.Unmarshal(b, c)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid JSON config")
@@ -26,6 +27,6 @@ func DecodeConfig(b []byte) (*Config, error) {
 	return c, nil
 }
 
-func EncodeConfig(c *Config) ([]byte, error) {
+func EncodeConnectionRequest(c *ConnectionRequest) ([]byte, error) {
 	return json.Marshal(c)
 }


### PR DESCRIPTION
- Simplify Client type. Now it does not hold Config inside
- Most of chshare.Config fields now initialized only once on Client startup
- chshare.Config renamed to chshare.ConnectionRequest. It's more precise name and also eliminates confusion with chserver.Config/chclient.Config

Part of DEV-1633 (config file implementation)