### PR TITLE
DEV-1759: Set default user agent to rport {version}

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -57,6 +57,9 @@ func (c *Config) ParseAndValidate() error {
 	if c.Connection.Hostname != "" {
 		c.Connection.headers.Set("Host", c.Connection.Hostname)
 	}
+	if len(c.Connection.headers.Values("User-Agent")) == 0 {
+		c.Connection.headers.Set("User-Agent", fmt.Sprintf("rport %s", chshare.BuildVersion))
+	}
 	return nil
 }
 

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -1,0 +1,66 @@
+package chclient
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigParseAndValidate(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		Config         Config
+		ExpectedHeader http.Header
+	}{
+		{
+			Name: "defaults",
+			ExpectedHeader: http.Header{
+				"User-Agent": []string{"rport 0.0.0-src"},
+			},
+		}, {
+			Name: "host set",
+			Config: Config{
+				Connection: ConnectionConfig{
+					Hostname: "test.com",
+				},
+			},
+			ExpectedHeader: http.Header{
+				"Host":       []string{"test.com"},
+				"User-Agent": []string{"rport 0.0.0-src"},
+			},
+		}, {
+			Name: "user agent set in config",
+			Config: Config{
+				Connection: ConnectionConfig{
+					HeadersRaw: []string{"User-Agent: test-agent"},
+				},
+			},
+			ExpectedHeader: http.Header{
+				"User-Agent": []string{"test-agent"},
+			},
+		}, {
+			Name: "multiple headers set",
+			Config: Config{
+				Connection: ConnectionConfig{
+					HeadersRaw: []string{"Test1: v1", "Test2: v2"},
+				},
+			},
+			ExpectedHeader: http.Header{
+				"Test1":      []string{"v1"},
+				"Test2":      []string{"v2"},
+				"User-Agent": []string{"rport 0.0.0-src"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			err := tc.Config.ParseAndValidate()
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.ExpectedHeader, tc.Config.Connection.Headers())
+		})
+	}
+}


### PR DESCRIPTION
Set default user agent to rport {version}, but allow user to override it with headers option.