### PR TITLE
DEV-1763: Refactor client config

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -35,10 +35,7 @@ func TestCustomHeaders(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	c, err := NewClient(&config)
-	if err != nil {
-		log.Fatal(err)
-	}
+	c := NewClient(&config)
 	if err = c.Run(); err != nil {
 		log.Fatal(err)
 	}

--- a/client/config.go
+++ b/client/config.go
@@ -36,6 +36,8 @@ type ClientConfig struct {
 	Tags        []string `mapstructure:"tags"`
 	Remotes     []string `mapstructure:"remotes"`
 	AllowRoot   bool     `mapstructure:"allow_root"`
+
+	proxyURL *url.URL
 }
 
 func (c *ConnectionConfig) Headers() http.Header {
@@ -53,6 +55,9 @@ func (c *Config) ParseAndValidate() error {
 		return err
 	}
 	if err := c.parseServerURL(); err != nil {
+		return err
+	}
+	if err := c.parseProxyURL(); err != nil {
 		return err
 	}
 	if c.Connection.MaxRetryInterval < time.Second {
@@ -104,6 +109,17 @@ func (c *Config) parseServerURL() error {
 	//swap to websockets scheme
 	u.Scheme = strings.Replace(u.Scheme, "http", "ws", 1)
 	c.Client.Server = u.String()
+	return nil
+}
+
+func (c *Config) parseProxyURL() error {
+	if p := c.Client.Proxy; p != "" {
+		proxyURL, err := url.Parse(p)
+		if err != nil {
+			return fmt.Errorf("Invalid proxy URL (%s)", err)
+		}
+		c.Client.proxyURL = proxyURL
+	}
 	return nil
 }
 

--- a/client/config.go
+++ b/client/config.go
@@ -38,6 +38,7 @@ type ClientConfig struct {
 	AllowRoot   bool     `mapstructure:"allow_root"`
 
 	proxyURL *url.URL
+	remotes  []*chshare.Remote
 }
 
 func (c *ConnectionConfig) Headers() http.Header {
@@ -58,6 +59,9 @@ func (c *Config) ParseAndValidate() error {
 		return err
 	}
 	if err := c.parseProxyURL(); err != nil {
+		return err
+	}
+	if err := c.parseRemotes(); err != nil {
 		return err
 	}
 	if c.Connection.MaxRetryInterval < time.Second {
@@ -119,6 +123,17 @@ func (c *Config) parseProxyURL() error {
 			return fmt.Errorf("Invalid proxy URL (%s)", err)
 		}
 		c.Client.proxyURL = proxyURL
+	}
+	return nil
+}
+
+func (c *Config) parseRemotes() error {
+	for _, s := range c.Client.Remotes {
+		r, err := chshare.DecodeRemote(s)
+		if err != nil {
+			return fmt.Errorf("Failed to decode remote '%s': %s", s, err)
+		}
+		c.Client.remotes = append(c.Client.remotes, r)
 	}
 	return nil
 }

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	chshare "github.com/cloudradar-monitoring/rport/share"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	chshare "github.com/cloudradar-monitoring/rport/share"
 )
 
 func TestConfigParseAndValidateHeaders(t *testing.T) {

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfigParseAndValidate(t *testing.T) {
+func TestConfigParseAndValidateHeaders(t *testing.T) {
 	testCases := []struct {
 		Name           string
 		Config         Config
@@ -57,10 +57,68 @@ func TestConfigParseAndValidate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
+			tc.Config.Client.Server = "test.com"
+
 			err := tc.Config.ParseAndValidate()
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.ExpectedHeader, tc.Config.Connection.Headers())
+		})
+	}
+}
+
+func TestConfigParseAndValidateServerURL(t *testing.T) {
+	testCases := []struct {
+		ServerURL     string
+		ExpectedURL   string
+		ExpectedError string
+	}{
+		{
+			ServerURL:     "",
+			ExpectedError: "Server address is required. See --help",
+		}, {
+			ServerURL:   "test.com",
+			ExpectedURL: "ws://test.com:80",
+		}, {
+			ServerURL:   "http://test.com",
+			ExpectedURL: "ws://test.com:80",
+		}, {
+			ServerURL:   "https://test.com",
+			ExpectedURL: "wss://test.com:443",
+		}, {
+			ServerURL:   "http://test.com:1234",
+			ExpectedURL: "ws://test.com:1234",
+		}, {
+			ServerURL:   "https://test.com:1234",
+			ExpectedURL: "wss://test.com:1234",
+		}, {
+			ServerURL:   "ws://test.com:1234",
+			ExpectedURL: "ws://test.com:1234",
+		}, {
+			ServerURL:   "wss://test.com:1234",
+			ExpectedURL: "wss://test.com:1234",
+		}, {
+			ServerURL:     "test\n.com",
+			ExpectedError: `Invalid server address: parse "http://test\n.com": net/url: invalid control character in URL`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.ServerURL, func(t *testing.T) {
+			config := &Config{
+				Client: ClientConfig{
+					Server: tc.ServerURL,
+				},
+			}
+			err := config.ParseAndValidate()
+
+			if tc.ExpectedError == "" {
+				require.NoError(t, err)
+				assert.Equal(t, tc.ExpectedURL, config.Client.Server)
+			} else {
+				require.Error(t, err)
+				assert.Equal(t, tc.ExpectedError, err.Error())
+			}
 		})
 	}
 }

--- a/cmd/rport/main.go
+++ b/cmd/rport/main.go
@@ -226,7 +226,7 @@ func runMain(cmd *cobra.Command, args []string) {
 
 	err = config.ParseAndValidate()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Invalid config: %v", err)
 	}
 
 	if !config.Client.AllowRoot && chshare.IsRunningAsRoot() {

--- a/cmd/rport/main.go
+++ b/cmd/rport/main.go
@@ -224,10 +224,6 @@ func runMain(cmd *cobra.Command, args []string) {
 		config.Client.Remotes = args[1:]
 	}
 
-	if config.Client.Server == "" {
-		log.Fatalf("Server address is required. See --help")
-	}
-
 	err = config.ParseAndValidate()
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/rport/main.go
+++ b/cmd/rport/main.go
@@ -249,10 +249,7 @@ func runMain(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	c, err := chclient.NewClient(config)
-	if err != nil {
-		log.Fatal(err)
-	}
+	c := chclient.NewClient(config)
 
 	if !service.Interactive() {
 		err = runAsService(c, *cfgPath)


### PR DESCRIPTION
Refactor client config:
- move all config parsing to `config.ParseAndValidate` from `NewClient`
- add config as direct attribute of `Client`
- `NewClient` does not return error
- add tests

There shouldn't be any changes in functionality in this pr.