### PR TITLE
DEV-1988: Use uuid4 for client IDs, Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Also, the server can run on any operation system supported by the golang compile
   * [Connect a client](#run-client)
   * [Run a Linux client with systemd](#linux-client-systemd)
   * [Run a Windows client](#windows-client)
-  * [run clients on other operating systems](#other-clients)
+  * [Run clients on other operating systems](#other-clients)
   * [Configuration files](#configs) 
   * [Using authentication](#client-auth)
 * [On-demand tunnels using the API](#on-demand-tunnels)
@@ -50,15 +50,16 @@ Also, the server can run on any operation system supported by the golang compile
 
 <a name="build-install"></a>
 ## Build and installation
-We provide [pre-compiled binaries](https://github.com/cloudradar-monitoring/rport/releases).
-### From source
-1) Build from source (Linux or Mac OS/X):
+1) We provide [pre-compiled binaries](https://github.com/cloudradar-monitoring/rport/releases).
+
+2) From source:
+    * Build from source (Linux or Mac OS/X):
     ```bash
     make all
     ```
     `rport` and `rportd` binaries will appear in directory.
 
-2) Build using Docker:
+    * Build using Docker:
     ```bash
     make docker-goreleaser
     ```
@@ -77,7 +78,6 @@ Minimal setup:
 
 See `./rportd --help` and `./rport --help` for more options, like:
 - Specifying certificate fingerprint to validate server authority
-- Client authentication using user:password pair
 - Restricting, which users can connect
 - Specifying additional intermediate HTTP proxy
 - Using POSIX signals to control running apps
@@ -90,8 +90,8 @@ See `./rportd --help` and `./rport --help` for more options, like:
 ### Run the server without installation
 If you quickly want to run the rport server without installation, run the following commands from any unprivileged user account.
 ```
-wget https://github.com/cloudradar-monitoring/rport/releases/download/0.1.23/rport_0.1.23_Linux_x86_64.tar.gz
-sudo tar vxzf rport_0.1.23_Linux_x86_64.tar.gz rportd
+wget https://github.com/cloudradar-monitoring/rport/releases/download/0.1.24/rport_0.1.24_Linux_x86_64.tar.gz
+sudo tar vxzf rport_0.1.24_Linux_x86_64.tar.gz rportd
 KEY=$(openssl rand -hex 18)
 ./rportd --log-level info --data-dir /var/tmp/ --key $KEY --auth user1:1234
 ```
@@ -116,13 +116,13 @@ If you do ssh or rdp through the tunnel, a hijacked tunnel will not expose your 
 #### Install the server
 For a proper installation execute the following steps.
 ```
-wget https://github.com/cloudradar-monitoring/rport/releases/download/0.1.23/rport_0.1.23_Linux_x86_64.tar.gz
-sudo tar vxzf rport_0.1.23_Linux_x86_64.tar.gz -C /usr/local/bin/ rportd
+wget https://github.com/cloudradar-monitoring/rport/releases/download/0.1.24/rport_0.1.24_Linux_x86_64.tar.gz
+sudo tar vxzf rport_0.1.24_Linux_x86_64.tar.gz -C /usr/local/bin/ rportd
 sudo useradd -d /var/lib/rport -m -U -r -s /bin/false rport
 sudo mkdir /etc/rport/
 sudo mkdir /var/log/rport/
 sudo chown rport /var/log/rport/
-sudo tar vxzf rport_0.1.23_Linux_x86_64.tar.gz -C /etc/rport/ rportd.example.conf
+sudo tar vxzf rport_0.1.24_Linux_x86_64.tar.gz -C /etc/rport/ rportd.example.conf
 sudo cp /etc/rport/rportd.example.conf /etc/rport/rportd.conf
 ```
 
@@ -131,7 +131,7 @@ Create a key for the server instance. Store this key and don't change it. You wi
 openssl rand -hex 18
 ```
 
-Open the `/etc/rport/rportd.conf` with an editor. Add the generated random string as `kee_seed`. All other default settings are suitable for a quick and secure start.
+Open the `/etc/rport/rportd.conf` with an editor. Add the generated random string as `key_seed`. All other default settings are suitable for a quick and secure start.
 
 Change to the rport user account and check your rportd starts without errors.
 ```
@@ -157,7 +157,7 @@ sudo systemctl enable rportd # Optionally start rportd on boot
 Assume, the client is called `client1.local.localdomain`.
 On your client just install the client binary
 ```
-curl -LSs https://github.com/cloudradar-monitoring/rport/releases/download/0.1.23/rport_0.1.23_Linux_x86_64.tar.gz|\
+curl -LSs https://github.com/cloudradar-monitoring/rport/releases/download/0.1.24/rport_0.1.24_Linux_x86_64.tar.gz|\
 tar vxzf - -C /usr/local/bin/ rport
 ```
 
@@ -173,13 +173,13 @@ Now you can access your machine behind a firewall through the tunnel. Try `ssh -
 ### Run a Linux client with systemd
 For a proper and permanent installation of the client execute the following steps.
 ```
-wget https://github.com/cloudradar-monitoring/rport/releases/download/0.1.23/rport_0.1.23_Linux_x86_64.tar.gz
-sudo tar vxzf rport_0.1.23_Linux_x86_64.tar.gz -C /usr/local/bin/ rport
+wget https://github.com/cloudradar-monitoring/rport/releases/download/0.1.24/rport_0.1.24_Linux_x86_64.tar.gz
+sudo tar vxzf rport_0.1.24_Linux_x86_64.tar.gz -C /usr/local/bin/ rport
 sudo useradd -d /var/lib/rport -U -m -r -s /bin/false rport
 sudo mkdir /etc/rport/
 sudo mkdir /var/log/rport/
 sudo chown rport /var/log/rport/
-sudo tar vxzf rport_0.1.23_Linux_x86_64.tar.gz -C /etc/rport/ rport.example.conf
+sudo tar vxzf rport_0.1.24_Linux_x86_64.tar.gz -C /etc/rport/ rport.example.conf
 sudo cp /etc/rport/rport.example.conf /etc/rport/rport.conf
 sudo rport --service install --service-user rport --config /etc/rport/rport.conf
 ```
@@ -202,7 +202,7 @@ This will establish a permanent tunnel and the local port 22 (SSH) of the client
 
 <a name="windows-client"></a>
 ### Run a Windows client
-On Microsoft Windows [download the latest client binary](https://github.com/cloudradar-monitoring/rport/releases/download/0.1.23/rport_0.1.23_Windows_x86_64.zip) and extract it ideally to `C:\Program Files\rport`. Rename the `rport.example.conf` to `rport.conf` and store it in `C:\Program Files\rport` too.
+On Microsoft Windows [download the latest client binary](https://github.com/cloudradar-monitoring/rport/releases/download/0.1.24/rport_0.1.24_Windows_x86_64.zip) and extract it ideally to `C:\Program Files\rport`. Rename the `rport.example.conf` to `rport.conf` and store it in `C:\Program Files\rport` too.
 Open the `rport.conf` file with a text editor. On older Windows use an editor that supports unix line breaks, like [notepad++](https://notepad-plus-plus.org/).
 
 A very minimalistic client configuration `rport.conf` can look like this:
@@ -298,7 +298,7 @@ Example of a human readable API status
     "connect_url": "http://0.0.0.0:8080",
     "fingerprint": "2a:c8:79:09:80:ba:7c:60:05:e5:2c:99:6d:75:56:24",
     "clients_count": 2,
-    "version": "0.1.23"
+    "version": "0.1.24"
   }
 }
 ```

--- a/docs/client-on-other-os.md
+++ b/docs/client-on-other-os.md
@@ -2,11 +2,11 @@
 ## On Mac OS (intel based)
 Open the terminal and as an unprivileged user download the binary and put it in `/usr/local/bin`
 ```
-curl -OL https://github.com/cloudradar-monitoring/rport/releases/download/0.1.23/rport_0.1.23_Darwin_x86_64.tar.gz
+curl -OL https://github.com/cloudradar-monitoring/rport/releases/download/0.1.24/rport_0.1.24_Darwin_x86_64.tar.gz
 test -e /usr/local/bin/||sudo mkdir /usr/local/bin
-sudo tar xzf rport_0.1.23_Darwin_x86_64.tar.gz -C /usr/local/bin/ rport
+sudo tar xzf rport_0.1.24_Darwin_x86_64.tar.gz -C /usr/local/bin/ rport
 sudo mkdir /etc/rport
-tar xzf rport_0.1.23_Darwin_x86_64.tar.gz rport.example.conf
+tar xzf rport_0.1.24_Darwin_x86_64.tar.gz rport.example.conf
 sudo mv rport.example.conf /etc/rport/rport.conf
 sudo mkdir /var/log/rport
 ```

--- a/server/client_listener.go
+++ b/server/client_listener.go
@@ -187,13 +187,11 @@ func (cl *ClientListener) handleWebsocket(w http.ResponseWriter, req *http.Reque
 
 	checkVersions(clog, connRequest.Version)
 
-	sshID := clients.GetSessionID(sshConn)
-
 	// get the current client auth id
 	clientAuthID := sshConn.User()
 
 	// client id
-	cid := cl.getCID(connRequest.ID, cl.config, clientAuthID, sshID)
+	cid := cl.getCID(connRequest.ID, cl.config, clientAuthID)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -233,7 +231,7 @@ func checkVersions(log *chshare.Logger, clientVersion string) {
 	log.Infof("Client version (%s) differs from server version (%s)", v, chshare.BuildVersion)
 }
 
-func (cl *ClientListener) getCID(reqID string, config *Config, clientAuthID string, sshSessionID string) string {
+func (cl *ClientListener) getCID(reqID string, config *Config, clientAuthID string) string {
 	if reqID != "" {
 		return reqID
 	}
@@ -243,7 +241,7 @@ func (cl *ClientListener) getCID(reqID string, config *Config, clientAuthID stri
 		return clientAuthID
 	}
 
-	return sshSessionID
+	return clients.NewClientID()
 }
 
 func getRemotes(tunnels []*clients.Tunnel) []*chshare.Remote {

--- a/server/clients/client.go
+++ b/server/clients/client.go
@@ -2,7 +2,6 @@ package clients
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -12,14 +11,11 @@ import (
 
 	"github.com/cloudradar-monitoring/rport/server/cgroups"
 	chshare "github.com/cloudradar-monitoring/rport/share"
+	"github.com/cloudradar-monitoring/rport/share/random"
 )
 
 // now is used to stub time.Now in tests
 var now = time.Now
-
-func GetSessionID(sshConn ssh.ConnMetadata) string {
-	return fmt.Sprintf("%x", sshConn.SessionID())
-}
 
 type ConnectionState string
 
@@ -200,4 +196,9 @@ func (c *Client) ConnectionState() ConnectionState {
 		return Connected
 	}
 	return Disconnected
+}
+
+// NewClientID generates a new client ID.
+func NewClientID() string {
+	return random.UUID4()
 }

--- a/server/clients/client_builder.go
+++ b/server/clients/client_builder.go
@@ -39,7 +39,7 @@ type ClientBuilder struct {
 func New(t *testing.T) ClientBuilder {
 	return ClientBuilder{
 		t:            t,
-		id:           generateRandomCID(),
+		id:           NewClientID(),
 		clientAuthID: generateRandomClientAuthID(),
 	}
 }
@@ -107,10 +107,6 @@ func (b ClientBuilder) Build() *Client {
 		Connection: b.conn,
 	}
 
-}
-
-func generateRandomCID() string {
-	return "cid-" + random.AlphaNum(12)
 }
 
 func generateRandomClientAuthID() string {


### PR DESCRIPTION
- Use `UUID4` for client ID instead of SSH connection ID;
- Fix README