### PR TITLE
DEV-2088-2090: Improvements

### DIFF
--- a/cmd/rportd/main.go
+++ b/cmd/rportd/main.go
@@ -285,7 +285,11 @@ func init() {
 	viperCfg.SetDefault("server.auth_multiuse_creds", true)
 	viperCfg.SetDefault("server.run_remote_cmd_timeout_sec", DefaultRunRemoteCmdTimeoutSec)
 	viperCfg.SetDefault("server.client_login_wait", 2)
+	viperCfg.SetDefault("server.max_failed_login", 5)
+	viperCfg.SetDefault("server.ban_time", 3600)
 	viperCfg.SetDefault("api.user_login_wait", 2)
+	viperCfg.SetDefault("api.max_failed_login", 10)
+	viperCfg.SetDefault("api.ban_time", 600)
 }
 
 func bindPFlags() {

--- a/cmd/rportd/main.go
+++ b/cmd/rportd/main.go
@@ -24,7 +24,7 @@ const (
 	DefaultCheckPortTimeout       = 2 * time.Second
 	DefaultExcludedPorts          = "1-1024"
 	DefaultServerAddress          = "0.0.0.0:8080"
-	DefaultLogLevel               = "error"
+	DefaultLogLevel               = "info"
 	DefaultRunRemoteCmdTimeoutSec = 60
 )
 
@@ -184,7 +184,7 @@ var serverHelp = `
 
     --service-user, An optional arg specifying user to run rportd service under. Only on linux. Defaults to rport.
 
-    --log-level, Specify log level. Values: "error", "info", "debug" (defaults to "error")
+    --log-level, Specify log level. Values: "error", "info", "debug" (defaults to "info")
 
     --log-file, -l, Specifies log file path. (defaults to empty string: log printed to stdout)
 

--- a/rportd.example.conf
+++ b/rportd.example.conf
@@ -158,8 +158,8 @@
   log_file = "/var/log/rport/rportd.log"
 
   ## Specify log level. Values: 'error', 'info', 'debug'.
-  ## Defaults to 'error'
-  log_level = "error"
+  ## Defaults to 'info'
+  log_level = "info"
 
   ## NOTE: THIS OPTION IS NOT AVAILABLE YET
   ## Specifies a log file path or database table for audit logging

--- a/server/api_listener.go
+++ b/server/api_listener.go
@@ -195,6 +195,12 @@ func (al *APIListener) lookupUser(r *http.Request) (authorized bool, username st
 
 	if bearerToken, bearerAuthProvided := getBearerToken(r); bearerAuthProvided {
 		authorized, username, err = al.handleBearerToken(bearerToken)
+		return
+	}
+
+	// case when no auth method is provided
+	if al.bannedUsers.IsBanned("") {
+		return false, "", ErrTooManyRequests
 	}
 
 	return

--- a/server/bearer_auth.go
+++ b/server/bearer_auth.go
@@ -66,12 +66,13 @@ func (al *APIListener) validateBearerToken(tokenStr string) (bool, string, *APIS
 		al.Debugf("failed to parse jwt token: %v", err)
 		return false, "", nil, nil
 	}
-	if !token.Valid || tk.Username == "" {
-		return false, "", nil, nil
-	}
 
 	if al.bannedUsers.IsBanned(tk.Username) {
 		return false, tk.Username, nil, ErrTooManyRequests
+	}
+
+	if !token.Valid || tk.Username == "" {
+		return false, "", nil, nil
 	}
 
 	apiSession, err := al.apiSessionRepo.FindOne(tokenStr)

--- a/server/client_listener.go
+++ b/server/client_listener.go
@@ -97,9 +97,9 @@ func (cl *ClientListener) authUser(c ssh.ConnMetadata, password []byte) (*ssh.Pe
 	clientAuthID := c.User()
 
 	if cl.bannedClientAuths.IsBanned(clientAuthID) {
-		cl.Infof("Failed login attempt for client auth id %q, forcing to wait for %s (%s)",
+		cl.Infof("Failed login attempt for client auth id %q, forcing to wait for %ss (%s)",
 			clientAuthID,
-			cl.config.Server.MaxFailedLogin,
+			cl.config.Server.ClientLoginWait,
 			cl.getIP(c.RemoteAddr()),
 		)
 		return nil, ErrTooManyRequests

--- a/server/client_listener.go
+++ b/server/client_listener.go
@@ -97,7 +97,11 @@ func (cl *ClientListener) authUser(c ssh.ConnMetadata, password []byte) (*ssh.Pe
 	clientAuthID := c.User()
 
 	if cl.bannedClientAuths.IsBanned(clientAuthID) {
-		cl.Infof("Too many requests for client auth id %q, ip address: %s", clientAuthID, cl.getIP(c.RemoteAddr()))
+		cl.Infof("Failed login attempt for client auth id %q, forcing to wait for %s (%s)",
+			clientAuthID,
+			cl.config.Server.MaxFailedLogin,
+			cl.getIP(c.RemoteAddr()),
+		)
 		return nil, ErrTooManyRequests
 	}
 


### PR DESCRIPTION
- update logging msg when client is forced to wait on bad login
- set defaults for banning clients and api users
- return 429 for empty string username when no auth method is provided
- use info log level as default