### PR TITLE
Dev 2454 rdp proxy

### DIFF
--- a/client/monitoring/monitor.go
+++ b/client/monitoring/monitor.go
@@ -147,7 +147,6 @@ func (m *Monitor) sendMeasurement() {
 			return
 		}
 
-		m.logger.Debugf("sending %d bytes of monitoring data to server", len(data))
 		_, _, err = m.conn.SendRequest(comm.RequestTypeSaveMeasurement, false, data)
 		if err != nil {
 			m.logger.Errorf("Could not send save_measurement: %v", err)

--- a/docs/no19-rdp-proxy.md
+++ b/docs/no19-rdp-proxy.md
@@ -1,0 +1,22 @@
+# RDP-Proxy 
+
+## Preface
+Starting with version 0.6.0 RPort has the ability to create a tunnel to a remote RDP server with a built-in HTTPS proxy. 
+RPort uses the Apache Guacamole Server to connect to the remote RDP Server, which brings the remote desktop into your browser without the need of an RDP viewer.
+If a rdp tunnel with https proxy is created, RPort first creates the tunnel to the remote machine and makes it available through the https proxy with path "/".
+Pointing the browser to this URL creates a websocket tunnel to connect the browser with the guacamole server and starts the connection to the remote RDP server.
+
+## Prerequisites
+* Apache Guacamole Server has to be running on 127.0.0.1:4822
+
+## Install Apache Guacamole Server
+
+* Either build Guacamole Server from source and run it, which is described [here](http://guacamole.incubator.apache.org/doc/gug/installing-guacamole.html).
+* Or use one of the provided Docker images for guacd, e.g. from [linuxserver.io](https://docs.linuxserver.io/images/docker-guacd)
+```
+docker pull lscr.io/linuxserver/guacd
+docker run -d --name=guacd -p 4822:4822 --net=host --restart unless-stopped lscr.io/linuxserver/guacd
+```
+Important: docker run with `--net=host` to connect to RPort tunnel on 127.0.0.1
+
+

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
+	github.com/wwt/guac v1.3.1
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208

--- a/go.sum
+++ b/go.sum
@@ -441,6 +441,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce h1:fb190+cK2Xz/dvi9Hv8eCYJYvIGUTN2/KLq1pT6CjEc=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/wwt/guac v1.3.1 h1:mInerrsMxndJRyZ1ItN4QWo6HRIYqMGq+iUBUeuj4xg=
+github.com/wwt/guac v1.3.1/go.mod h1:eKm+NrnK7A88l4UBEcYNpZQGMpZRryYKoz4D/0/n1C0=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=

--- a/server/api.go
+++ b/server/api.go
@@ -1224,6 +1224,7 @@ const (
 	ErrCodeInvalidACL            = "ERR_CODE_INVALID_ACL"
 )
 
+//nolint:gocyclo
 func (al *APIListener) handlePutClientTunnel(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	clientID := vars[routeParamClientID]
@@ -1321,7 +1322,7 @@ func (al *APIListener) handlePutClientTunnel(w http.ResponseWriter, req *http.Re
 		al.jsonErrorResponseWithTitle(w, http.StatusBadRequest, "creation of tunnel proxy not enabled")
 		return
 	}
-	if isHTTPProxy && schemeStr != "http" && schemeStr != "https" && schemeStr != "vnc" {
+	if isHTTPProxy && schemeStr != "http" && schemeStr != "https" && schemeStr != "vnc" && schemeStr != "rdp" {
 		al.jsonErrorResponseWithTitle(w, http.StatusBadRequest, fmt.Sprintf("tunnel proxy not allowed with scheme %s", schemeStr))
 		return
 	}

--- a/server/clients/client.go
+++ b/server/clients/client.go
@@ -171,6 +171,12 @@ func (c *Client) StartTunnel(r *models.Remote, acl *clienttunnel.TunnelACL, tunn
 			case <-autoCloseChan:
 				c.Lock()
 				defer c.Unlock()
+				//stop tunnel proxy
+				if t.Proxy != nil {
+					if err := t.Proxy.Stop(c.Context); err != nil {
+						c.Logger.Errorf("error while stopping tunnel proxy: %v", err)
+					}
+				}
 				c.removeTunnelByID(t.ID)
 				c.Logger.Debugf("tunnel with id=%s removed", t.ID)
 			}

--- a/server/clients/client.go
+++ b/server/clients/client.go
@@ -135,7 +135,7 @@ func (c *Client) StartTunnel(r *models.Remote, acl *clienttunnel.TunnelACL, tunn
 			return nil, err
 		}
 		r.LocalPort = strconv.Itoa(port)
-		acl, _ = clienttunnel.ParseTunnelACL(clienttunnel.LocalHost) // access to tunnel is only allowed from tunnel proxy
+		acl = nil
 	}
 
 	tunnelID := strconv.FormatInt(c.generateNewTunnelID(), 10)

--- a/server/clients/clienttunnel/guac/index.html
+++ b/server/clients/clienttunnel/guac/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta name="robots" content="noindex">
+    <title>RPort RDP</title>
+    <link rel="icon" href="data:,">
+    <script  src="https://cdn.jsdelivr.net/npm/guacamole-common-js@1.3.1/dist/guacamole-common.min.js"></script>
+</head>
+
+<body>
+    <div id="display" style="width: 1024px; height: 768px">
+    </div>
+</body>
+<script>
+        const tunnel = new Guacamole.WebSocketTunnel('websocket-tunnel');
+
+        const client = new Guacamole.Client(tunnel);
+
+        client.onerror = (error) => {
+            console.error(error);
+        };
+
+        window.onunload = () => {
+            client.disconnect();
+        };
+
+        document.getElementById("display").append(
+            client.getDisplay().getElement());
+
+        try {
+            client.connect("");
+        } catch (error) {
+            console.error(error);
+        }
+
+        let mouse = new Guacamole.Mouse(client.getDisplay().getElement());
+
+        mouse.onmousedown = mouse.onmouseup = mouse.onmousemove = (mouseState) => {
+            client.sendMouseState(mouseState);
+        };
+
+        let keyboard = new Guacamole.Keyboard(document);
+
+        keyboard.onkeydown = (keysym) => {
+            client.sendKeyEvent(1, keysym);
+            return false;
+        };
+
+        keyboard.onkeyup = (keysym) => {
+            client.sendKeyEvent(0, keysym);
+            return false;
+        };
+</script>
+</html>

--- a/server/clients/clienttunnel/tunnel_proxy_connector.go
+++ b/server/clients/clienttunnel/tunnel_proxy_connector.go
@@ -15,6 +15,8 @@ func NewTunnelProxyConnector(tp *TunnelProxy) TunnelProxyConnector {
 		return NewTunnelConnectorHTTP(tp)
 	case "vnc":
 		return NewTunnelConnectorVNC(tp)
+	case "rdp":
+		return NewTunnelConnectorRDP(tp)
 	}
 
 	return nil

--- a/server/clients/clienttunnel/tunnel_proxy_connector_rdp.go
+++ b/server/clients/clienttunnel/tunnel_proxy_connector_rdp.go
@@ -1,0 +1,95 @@
+package clienttunnel
+
+import (
+	_ "embed" //to embed novnc wrapper templates
+	"html/template"
+	"net"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/wwt/guac"
+)
+
+//go:embed guac/index.html
+var guacIndexHTML string
+
+//TunnelProxyConnectorRDP connects to a rdp tunnel via guacd (Guacamole server)
+type TunnelProxyConnectorRDP struct {
+	tunnelProxy         *TunnelProxy
+	guacWebsocketServer *guac.WebsocketServer
+}
+
+func NewTunnelConnectorRDP(tp *TunnelProxy) *TunnelProxyConnectorRDP {
+	tpc := &TunnelProxyConnectorRDP{tunnelProxy: tp}
+	tpc.guacWebsocketServer = guac.NewWebsocketServer(tpc.connectToGuacamole)
+
+	return tpc
+}
+
+//InitRouter called when tunnel proxy is started
+func (tc *TunnelProxyConnectorRDP) InitRouter(router *mux.Router) *mux.Router {
+	router.Use(noCache)
+
+	router.Handle("/websocket-tunnel", tc.guacWebsocketServer)
+
+	router.HandleFunc("/", tc.serveIndex)
+
+	return router
+}
+
+func (tc *TunnelProxyConnectorRDP) serveIndex(w http.ResponseWriter, r *http.Request) {
+	tc.serveTemplate(w, r, guacIndexHTML, map[string]interface{}{})
+}
+
+func (tc *TunnelProxyConnectorRDP) serveTemplate(w http.ResponseWriter, r *http.Request, templateContent string, templateData map[string]interface{}) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+
+	tmpl, err := template.New("").Parse(templateContent)
+	if err == nil {
+		err = tmpl.Execute(w, templateData)
+	}
+	if err != nil {
+		tc.tunnelProxy.Logger.Errorf("Error while serving template for request %s: %v", r.RequestURI, err)
+	}
+}
+
+// connectToGuacamole creates the tunnel to the remote machine (via guacd)
+func (tc *TunnelProxyConnectorRDP) connectToGuacamole(request *http.Request) (guac.Tunnel, error) {
+	tc.tunnelProxy.Logger.Infof("TunnelProxyConnectorRDP: connect to tunnel: %s", tc.tunnelProxy.TunnelAddr())
+	config := guac.NewGuacamoleConfiguration()
+
+	config.Protocol = "rdp"
+	config.Parameters["hostname"] = "127.0.0.1"
+	config.Parameters["port"] = tc.tunnelProxy.TunnelPort
+	config.Parameters["ignore-cert"] = "true"
+
+	config.AudioMimetypes = []string{"audio/L16", "rate=44100", "channels=2"}
+
+	tc.tunnelProxy.Logger.Debugf("Connecting to guacd")
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:4822")
+	if err != nil {
+		tc.tunnelProxy.Logger.Errorf("error while resolving guacd address:%v", err)
+	}
+
+	conn, err := net.DialTCP("tcp", nil, addr)
+	if err != nil {
+		tc.tunnelProxy.Logger.Errorf("error while connecting to guacd:%v", err)
+		return nil, err
+	}
+
+	stream := guac.NewStream(conn, guac.SocketTimeout)
+
+	tc.tunnelProxy.Logger.Debugf("Connected to guacd")
+	if request.URL.Query().Get("uuid") != "" {
+		config.ConnectionID = request.URL.Query().Get("uuid")
+	}
+	tc.tunnelProxy.Logger.Debugf("Starting handshake with %#v", config)
+	err = stream.Handshake(config)
+	if err != nil {
+		tc.tunnelProxy.Logger.Errorf("Handshaking with guacd failed with %#v", err)
+		return nil, err
+	}
+	tc.tunnelProxy.Logger.Debugf("Socket configured")
+	return guac.NewSimpleTunnel(stream), nil
+}


### PR DESCRIPTION
New RPort RDP tunnel proxy. HTTPS proxy in front of RDP tunnel using Apache Guacamole to provide connection to remote RDP Server from browser.