### PR TITLE
DEV-2455: Add job summary output sent back from client

### DIFF
--- a/share/models/job.go
+++ b/share/models/job.go
@@ -39,8 +39,9 @@ type JobSummary struct {
 }
 
 type JobResult struct {
-	StdOut string `json:"stdout"`
-	StdErr string `json:"stderr"`
+	StdOut  string `json:"stdout"`
+	StdErr  string `json:"stderr"`
+	Summary string `json:"summary"`
 }
 
 type MultiJob struct {


### PR DESCRIPTION
Capture everything between `<summary>` and `</summary>`. Make it part of the job result.