### PR TITLE
[DEV-2455] Allow disconnected clients when starting schedule execution

### DIFF
--- a/server/upload.go
+++ b/server/upload.go
@@ -274,7 +274,7 @@ func (al *APIListener) uploadRequestFromRequest(req *http.Request) (*UploadReque
 	ur.ClientIDs = req.MultipartForm.Value["client_id"]
 	ur.GroupIDs = req.MultipartForm.Value["group_id"]
 
-	ur.Clients, ur.clientsInGroupsCount, err = al.getOrderedClients(req.Context(), ur.ClientIDs, ur.GroupIDs)
+	ur.Clients, ur.clientsInGroupsCount, err = al.getOrderedClients(req.Context(), ur.ClientIDs, ur.GroupIDs, false /* allowDisconnected */)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently whole schedule execution failed if one of the clients was disconnected. This allows disconnected clients when listing clients for schedule execution and saves appropriate error for jobs on disconnected clients later.