### PR TITLE
Add client id and client name to partial script outputs

### DIFF
--- a/api-doc/openapi/components/schemas/JobPartial.yaml
+++ b/api-doc/openapi/components/schemas/JobPartial.yaml
@@ -3,6 +3,12 @@ properties:
   jid:
     type: string
     description: job ID
+  client_id:
+    type: string
+    description: client ID
+  client_name:
+    type: string
+    description: client name
   result:
     type: object
     properties:

--- a/server/client_listener.go
+++ b/server/client_listener.go
@@ -534,8 +534,10 @@ func (cl *ClientListener) handleSSHChannels(clientLog *logger.Logger, chans <-ch
 }
 
 type outputChannelData struct {
-	JID    string            `json:"jid"`
-	Result *models.JobResult `json:"result"`
+	JID        string            `json:"jid"`
+	ClientID   string            `json:"client_id"`
+	ClientName string            `json:"client_name"`
+	Result     *models.JobResult `json:"result"`
 }
 
 func (cl *ClientListener) handleOutputChannel(typ string, jobData []byte, clientLog *logger.Logger, stream io.Reader) error {
@@ -554,7 +556,9 @@ func (cl *ClientListener) handleOutputChannel(typ string, jobData []byte, client
 	ws := cl.Server.uiJobWebSockets.Get(wsJID)
 
 	ocd := outputChannelData{
-		JID: job.JID,
+		JID:        job.JID,
+		ClientID:   job.ClientID,
+		ClientName: job.ClientName,
 	}
 
 	data := make([]byte, 4096)


### PR DESCRIPTION
Client Id and name are needed by rportcli for correct output.