### PR TITLE
Fixes for update checks on CentOS-like Redhat OS using yum

### DIFF
--- a/client/updates/yum.go
+++ b/client/updates/yum.go
@@ -38,7 +38,7 @@ func (p *YumPackageManager) GetUpdatesStatus(ctx context.Context, logger *logger
 	// --refresh doesn't work on CentOS, replace with clean expire-cache which should be supported by both dnf and yum
 	cmd := append([]string{"clean", "expire-cache", "--quiet"})
         _, err := p.run(ctx, cmd...)
-	if err != nil && err.Error() != "exit status 1" {
+	if err != nil {
         	return nil, err
         }
 


### PR DESCRIPTION
These changes allow rport to successfully list and detail updates available on CentOS.

Tested on CentOS 7, testing on later CentOS/Rocky/Alma as well as RHEL is advised.

Notes from comments:

Security updates will always be 0 on CentOS-like Redhat without EPEL, as core CentOS doesn't include security metadata
"needs-restarting" requires the yum-utils package