### PR TITLE
[DEV-2700] Too many db locks

### DIFF
--- a/db/sqlite/sqlite.go
+++ b/db/sqlite/sqlite.go
@@ -67,8 +67,8 @@ func New(dataSourceName string, assetNames []string, asset func(name string) ([]
 	return db, nil
 }
 
-func WithRetryWhenBusy[R any](retryAble func() (result R, err error), label string, l *logger.Logger, maxAttempts int) (result R, err error) {
-	for r := 0; r < maxAttempts; r++ {
+func WithRetryWhenBusy[R any](retryAble func() (result R, err error), label string, l *logger.Logger) (result R, err error) {
+	for r := 0; r < DefaultMaxAttempts; r++ {
 		result, err = retryAble()
 		if err != nil {
 			sqlErr, ok := err.(sql.Error)

--- a/db/sqlite/sqlite.go
+++ b/db/sqlite/sqlite.go
@@ -3,14 +3,22 @@ package sqlite
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/sqlite3"
 	bindata "github.com/golang-migrate/migrate/v4/source/go_bindata"
 	"github.com/jmoiron/sqlx"
+	sql "github.com/mattn/go-sqlite3"
+
+	"github.com/cloudradar-monitoring/rport/share/logger"
 )
 
-const WALEnabled = "_journal_mode=WAL"
+const (
+	WALEnabled                  = "_journal_mode=WAL"
+	defaultDelayBetweenAttempts = 10 * time.Millisecond
+	DefaultMaxAttempts          = 3
+)
 
 type DataSourceOptions struct {
 	WALEnabled bool
@@ -57,4 +65,25 @@ func New(dataSourceName string, assetNames []string, asset func(name string) ([]
 	}
 
 	return db, nil
+}
+
+func WithRetryWhenBusy[R any](retryAble func() (result R, err error), label string, l *logger.Logger, maxAttempts int) (result R, err error) {
+	for r := 0; r < maxAttempts; r++ {
+		result, err = retryAble()
+		if err != nil {
+			sqlErr, ok := err.(sql.Error)
+			if ok && sqlErr.Code == sql.ErrBusy {
+				l.Debugf("%s: attempt %d: source err = %+v\n", label, r+1, err)
+				time.Sleep(defaultDelayBetweenAttempts)
+				continue
+			}
+			// non retryable err
+			return result, sqlErr
+		}
+		// success
+		return result, nil
+	}
+
+	l.Debugf("%s: failed after max attempts: err = %+v\n", label, err)
+	return result, err
 }

--- a/db/sqlite/sqlite_test.go
+++ b/db/sqlite/sqlite_test.go
@@ -37,7 +37,7 @@ func TestShouldSucceedWhenNoError(t *testing.T) {
 
 	_, err := WithRetryWhenBusy(func() (result any, err error) {
 		return nil, nil
-	}, "test", testLog, DefaultMaxAttempts)
+	}, "test", testLog)
 
 	assert.NoError(t, err)
 }
@@ -55,7 +55,7 @@ func TestShouldSucceedAfterRetries(t *testing.T) {
 			}
 		}
 		return nil, nil
-	}, "test", testLog, DefaultMaxAttempts)
+	}, "test", testLog)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 2, attempts)
@@ -71,7 +71,7 @@ func TestShouldFailWhenMaxBusyErrors(t *testing.T) {
 		return nil, sql.Error{
 			Code: sql.ErrBusy,
 		}
-	}, "test", testLog, DefaultMaxAttempts)
+	}, "test", testLog)
 
 	assert.EqualError(t, err, sql.ErrBusy.Error())
 	assert.Equal(t, DefaultMaxAttempts, attempts)
@@ -88,7 +88,7 @@ func TestShouldFailImmediatelyWhenNonBusyError(t *testing.T) {
 		return nil, sql.Error{
 			Code: sql.ErrCorrupt,
 		}
-	}, "test", testLog, DefaultMaxAttempts)
+	}, "test", testLog)
 
 	assert.EqualError(t, err, sql.ErrCorrupt.Error())
 	assert.Equal(t, 1, attempts)

--- a/db/sqlite/sqlite_test.go
+++ b/db/sqlite/sqlite_test.go
@@ -4,10 +4,12 @@ import (
 	"os"
 	"testing"
 
+	sql "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cloudradar-monitoring/rport/db/migration/dummy"
+	"github.com/cloudradar-monitoring/rport/share/logger"
 )
 
 func TestSqliteWALEnabled(t *testing.T) {
@@ -28,4 +30,66 @@ func TestSqliteWALDisabled(t *testing.T) {
 	assert.ErrorIs(t, err, os.ErrNotExist)
 	_, err = os.Stat(dataSourceName + "-wal")
 	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestShouldSucceedWhenNoError(t *testing.T) {
+	testLog := logger.NewLogger("retries", logger.LogOutput{File: os.Stdout}, logger.LogLevelDebug)
+
+	_, err := WithRetryWhenBusy(func() (result any, err error) {
+		return nil, nil
+	}, "test", testLog, DefaultMaxAttempts)
+
+	assert.NoError(t, err)
+}
+
+func TestShouldSucceedAfterRetries(t *testing.T) {
+	testLog := logger.NewLogger("retries", logger.LogOutput{File: os.Stdout}, logger.LogLevelDebug)
+
+	attempts := 0
+
+	_, err := WithRetryWhenBusy(func() (result any, err error) {
+		if attempts < 2 {
+			attempts++
+			return nil, sql.Error{
+				Code: sql.ErrBusy,
+			}
+		}
+		return nil, nil
+	}, "test", testLog, DefaultMaxAttempts)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, attempts)
+}
+
+func TestShouldFailWhenMaxBusyErrors(t *testing.T) {
+	testLog := logger.NewLogger("retries", logger.LogOutput{File: os.Stdout}, logger.LogLevelDebug)
+
+	attempts := 0
+
+	_, err := WithRetryWhenBusy(func() (result any, err error) {
+		attempts++
+		return nil, sql.Error{
+			Code: sql.ErrBusy,
+		}
+	}, "test", testLog, DefaultMaxAttempts)
+
+	assert.EqualError(t, err, sql.ErrBusy.Error())
+	assert.Equal(t, DefaultMaxAttempts, attempts)
+}
+
+func TestShouldFailImmediatelyWhenNonBusyError(t *testing.T) {
+	testLog := logger.NewLogger("retries", logger.LogOutput{File: os.Stdout}, logger.LogLevelDebug)
+
+	attempts := 0
+
+	_, err := WithRetryWhenBusy(func() (result any, err error) {
+		attempts++
+		// fail immediately when not sql.ErrBusy
+		return nil, sql.Error{
+			Code: sql.ErrCorrupt,
+		}
+	}, "test", testLog, DefaultMaxAttempts)
+
+	assert.EqualError(t, err, sql.ErrCorrupt.Error())
+	assert.Equal(t, 1, attempts)
 }

--- a/server/api/jobs/jobs.go
+++ b/server/api/jobs/jobs.go
@@ -167,7 +167,7 @@ func (p *SqliteProvider) SaveJob(job *models.Job) error {
 		VALUES (:jid, :status, :started_at, :finished_at, :created_by, :client_id, :multi_job_id, :details)`,
 			convertToSqlite(job))
 		return result, err
-	}, "savejob", p.log, sqlite.DefaultMaxAttempts)
+	}, "savejob", p.log)
 
 	if err == nil {
 		p.log.Debugf("Job saved successfully: %v", *job)
@@ -182,7 +182,7 @@ func (p *SqliteProvider) CreateJob(job *models.Job) error {
 		VALUES (:jid, :status, :started_at, :finished_at, :created_by, :client_id, :multi_job_id, :details)`,
 			convertToSqlite(job))
 		return result, err
-	}, "createjob", p.log, sqlite.DefaultMaxAttempts)
+	}, "createjob", p.log)
 	if err != nil {
 		// check if it's "already exist" err
 		typeErr, ok := err.(sqlite3.Error)

--- a/server/api/jobs/jobs.go
+++ b/server/api/jobs/jobs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattn/go-sqlite3"
 	"github.com/pkg/errors"
 
+	"github.com/cloudradar-monitoring/rport/db/sqlite"
 	"github.com/cloudradar-monitoring/rport/share/logger"
 	"github.com/cloudradar-monitoring/rport/share/models"
 	"github.com/cloudradar-monitoring/rport/share/query"
@@ -161,9 +162,13 @@ func (p *SqliteProvider) Count(ctx context.Context, options *query.ListOptions) 
 
 // SaveJob creates a new or updates an existing job.
 func (p *SqliteProvider) SaveJob(job *models.Job) error {
-	_, err := p.db.NamedExec(`INSERT OR REPLACE INTO jobs (jid, status, started_at, finished_at, created_by, client_id, multi_job_id, details)
-														VALUES (:jid, :status, :started_at, :finished_at, :created_by, :client_id, :multi_job_id, :details)`,
-		convertToSqlite(job))
+	_, err := sqlite.WithRetryWhenBusy(func() (result sql.Result, err error) {
+		result, err = p.db.NamedExec(`INSERT OR REPLACE INTO jobs (jid, status, started_at, finished_at, created_by, client_id, multi_job_id, details)
+		VALUES (:jid, :status, :started_at, :finished_at, :created_by, :client_id, :multi_job_id, :details)`,
+			convertToSqlite(job))
+		return result, err
+	}, "savejob", p.log, sqlite.DefaultMaxAttempts)
+
 	if err == nil {
 		p.log.Debugf("Job saved successfully: %v", *job)
 	}
@@ -172,9 +177,12 @@ func (p *SqliteProvider) SaveJob(job *models.Job) error {
 
 // CreateJob creates a new job. If already exists with the same ID - does nothing and returns nil.
 func (p *SqliteProvider) CreateJob(job *models.Job) error {
-	_, err := p.db.NamedExec(`INSERT INTO jobs (jid, status, started_at, finished_at, created_by, client_id, multi_job_id, details)
-											VALUES (:jid, :status, :started_at, :finished_at, :created_by, :client_id, :multi_job_id, :details)`,
-		convertToSqlite(job))
+	_, err := sqlite.WithRetryWhenBusy(func() (result sql.Result, err error) {
+		result, err = p.db.NamedExec(`INSERT INTO jobs (jid, status, started_at, finished_at, created_by, client_id, multi_job_id, details)
+		VALUES (:jid, :status, :started_at, :finished_at, :created_by, :client_id, :multi_job_id, :details)`,
+			convertToSqlite(job))
+		return result, err
+	}, "createjob", p.log, sqlite.DefaultMaxAttempts)
 	if err != nil {
 		// check if it's "already exist" err
 		typeErr, ok := err.(sqlite3.Error)

--- a/server/monitoring/sqlite.go
+++ b/server/monitoring/sqlite.go
@@ -192,7 +192,7 @@ func (p *SqliteProvider) CreateMeasurement(ctx context.Context, measurement *mod
 	_, err := sqlite.WithRetryWhenBusy(func() (result sql.Result, err error) {
 		result, err = p.db.NamedExecContext(ctx, query, measurement)
 		return result, err
-	}, "createmeasurement", p.logger, sqlite.DefaultMaxAttempts)
+	}, "createmeasurement", p.logger)
 
 	return err
 }


### PR DESCRIPTION
This PR adds explicit retry attempts when sqlite returns busy db errors (aka locked database errors). 

Other options considered were to use busy timeouts or restrict max open connections to 1. Using busy timeouts resulted in more busy errors (surprisingly) and limiting the max open connections lowered performance of writes to approx 1/2 the previous performance (not surprisingly).

https://tracker.rport.io/issue/DEV-2700/Too-many-db-locks

