### PR TITLE
[DEV-2709] Improve logging

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -351,7 +351,7 @@ func PrepareDirs(c *ClientConfigHolder) error {
 		return fmt.Errorf("failed to create dir %q: %s", c.Client.DataDir, err)
 	}
 
-	logger.Infof("data directory path: %q", c.Client.DataDir)
+	logger.Debugf("Data directory path: %q", c.Client.DataDir)
 
 	scriptDir := c.GetScriptsDir()
 	if _, err := os.Stat(scriptDir); os.IsNotExist(err) {

--- a/client/updates/updates.go
+++ b/client/updates/updates.go
@@ -104,9 +104,9 @@ func (u *Updates) refreshStatus(ctx context.Context) {
 	newStatus.Refreshed = time.Now()
 
 	if newStatus.Error != "" {
-		u.logger.Infof("Update status refresh failed: %v", newStatus.Error)
+		u.logger.Infof("Refreshing OS patch level (pending updates) failed: %v", newStatus.Error)
 	} else {
-		u.logger.Infof("Update status refreshed, %v updates available (%v security)",
+		u.logger.Infof("OS patch level (pending updates) refreshed, %v updates available (%v security)",
 			newStatus.UpdatesAvailable, newStatus.SecurityUpdatesAvailable)
 	}
 

--- a/cmd/rport/main.go
+++ b/cmd/rport/main.go
@@ -130,7 +130,7 @@ var clientHelp = `
 
     --service-user, An optional arg specifying user to run rport service under. Only on linux. Defaults to rport.
 
-    --log-level, Specify log level. Values: "error", "info", "debug" (defaults to "error")
+    --log-level, Specify log level. Values: "error", "info", "debug" (defaults to "info")
 
     --log-file, -l, Specifies log file path. (defaults to empty string: log printed to stdout)
 
@@ -282,7 +282,7 @@ func init() {
 	viperCfg.SetConfigType("toml")
 
 	viperCfg.SetDefault("client.server_switchback_interval", 2*time.Minute)
-	viperCfg.SetDefault("logging.log_level", "error")
+	viperCfg.SetDefault("logging.log_level", "info")
 	viperCfg.SetDefault("connection.max_retry_count", -1)
 	viperCfg.SetDefault("connection.keep_alive", "3m")
 	viperCfg.SetDefault("connection.keep_alive_timeout", "30s")

--- a/server/api_clientauth_test.go
+++ b/server/api_clientauth_test.go
@@ -508,7 +508,7 @@ func TestHandleDeleteClientAuth(t *testing.T) {
 			al := APIListener{
 				insecureForTests: true,
 				Server: &Server{
-					clientService: NewClientService(nil, nil, clients.NewClientRepository(tc.clients, &hour, testLog)),
+					clientService: NewClientService(nil, nil, clients.NewClientRepository(tc.clients, &hour, testLog), testLog),
 					config: &chconfig.Config{
 						Server: chconfig.ServerConfig{
 							AuthWrite:       tc.clientAuthWrite,

--- a/server/api_handler_clients.go
+++ b/server/api_handler_clients.go
@@ -337,12 +337,10 @@ func (al *APIListener) handlePutClientTunnel(w http.ResponseWriter, req *http.Re
 		return
 	}
 
-	attemptingClientReconnect := false
 	if client == nil {
 		al.Debugf("active client with id %s not found", clientID)
 		// there isn't an active client, but let's see if there's a disconnect client and if so then
 		// try creating tunnels anyway by continuing with the non-active client.
-		attemptingClientReconnect = true
 		client, err = al.clientService.GetByID(clientID)
 		if err != nil {
 			al.jsonErrorResponse(w, http.StatusInternalServerError, err)
@@ -453,7 +451,7 @@ func (al *APIListener) handlePutClientTunnel(w http.ResponseWriter, req *http.Re
 		return
 	}
 
-	tunnels, err := al.clientService.StartClientTunnels(client, []*models.Remote{remote}, attemptingClientReconnect)
+	tunnels, err := al.clientService.StartClientTunnels(client, []*models.Remote{remote})
 	if err != nil {
 		al.jsonError(w, err)
 		return

--- a/server/api_handler_clients_test.go
+++ b/server/api_handler_clients_test.go
@@ -369,7 +369,7 @@ func (mcs *SimpleMockClientService) GetActiveByID(id string) (*clients.Client, e
 	return mcs.ActiveClients[0], nil
 }
 
-func (mcs *SimpleMockClientService) StartClientTunnels(client *clients.Client, remotes []*models.Remote, forcing bool) ([]*clienttunnel.Tunnel, error) {
+func (mcs *SimpleMockClientService) StartClientTunnels(client *clients.Client, remotes []*models.Remote) ([]*clienttunnel.Tunnel, error) {
 	tunnels := make([]*clienttunnel.Tunnel, 0, 32)
 	for i, remote := range remotes {
 		tunnels = append(tunnels, makeTunnelResponse(mcs.ExpectedIDs[i], remote))

--- a/server/api_handler_clients_test.go
+++ b/server/api_handler_clients_test.go
@@ -369,7 +369,7 @@ func (mcs *SimpleMockClientService) GetActiveByID(id string) (*clients.Client, e
 	return mcs.ActiveClients[0], nil
 }
 
-func (mcs *SimpleMockClientService) StartClientTunnels(client *clients.Client, remotes []*models.Remote) ([]*clienttunnel.Tunnel, error) {
+func (mcs *SimpleMockClientService) StartClientTunnels(client *clients.Client, remotes []*models.Remote, forcing bool) ([]*clienttunnel.Tunnel, error) {
 	tunnels := make([]*clienttunnel.Tunnel, 0, 32)
 	for i, remote := range remotes {
 		tunnels = append(tunnels, makeTunnelResponse(mcs.ExpectedIDs[i], remote))

--- a/server/api_handler_clients_test.go
+++ b/server/api_handler_clients_test.go
@@ -39,7 +39,7 @@ func TestHandleGetClient(t *testing.T) {
 	al := APIListener{
 		insecureForTests: true,
 		Server: &Server{
-			clientService: NewClientService(nil, nil, clients.NewClientRepository([]*clients.Client{c1}, &hour, testLog)),
+			clientService: NewClientService(nil, nil, clients.NewClientRepository([]*clients.Client{c1}, &hour, testLog), testLog),
 			config: &chconfig.Config{
 				Server: chconfig.ServerConfig{MaxRequestBytes: 1024 * 1024},
 			},
@@ -174,7 +174,7 @@ func TestHandleGetClients(t *testing.T) {
 	al := APIListener{
 		insecureForTests: true,
 		Server: &Server{
-			clientService: NewClientService(nil, nil, clients.NewClientRepository([]*clients.Client{c1, c2}, &hour, testLog)),
+			clientService: NewClientService(nil, nil, clients.NewClientRepository([]*clients.Client{c1, c2}, &hour, testLog), testLog),
 			config: &chconfig.Config{
 				Server: chconfig.ServerConfig{MaxRequestBytes: 1024 * 1024},
 			},

--- a/server/api_handler_commands_test.go
+++ b/server/api_handler_commands_test.go
@@ -272,7 +272,7 @@ func TestHandlePostCommand(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
-			clientService := NewClientService(nil, nil, clients.NewClientRepository(tc.clients, &hour, testLog))
+			clientService := NewClientService(nil, nil, clients.NewClientRepository(tc.clients, &hour, testLog), testLog)
 			al := APIListener{
 				insecureForTests: true,
 				Server: &Server{
@@ -641,7 +641,7 @@ func TestHandlePostMultiClientCommand(t *testing.T) {
 			al := APIListener{
 				insecureForTests: true,
 				Server: &Server{
-					clientService: NewClientService(nil, nil, clients.NewClientRepository([]*clients.Client{c1, c2, c3}, &hour, testLog)),
+					clientService: NewClientService(nil, nil, clients.NewClientRepository([]*clients.Client{c1, c2, c3}, &hour, testLog), testLog),
 					config: &chconfig.Config{
 						Server: chconfig.ServerConfig{
 							RunRemoteCmdTimeoutSec: defaultTimeout,
@@ -1901,7 +1901,7 @@ func makeAPIListener(
 	clientRepo *clients.ClientRepository,
 	defaultTimeout int,
 	testLog *logger.Logger) (al *APIListener) {
-	clientService := NewClientService(nil, nil, clientRepo)
+	clientService := NewClientService(nil, nil, clientRepo, testLog)
 	al = &APIListener{
 		insecureForTests: true,
 		Server: &Server{

--- a/server/api_handler_monitoring_test.go
+++ b/server/api_handler_monitoring_test.go
@@ -59,7 +59,7 @@ func TestHandleRefreshUpdatesStatus(t *testing.T) {
 			connMock.ReturnOk = !tc.SSHError
 			c1.Connection = connMock
 
-			clientService := NewClientService(nil, nil, clients.NewClientRepository([]*clients.Client{c1, c2}, &hour, testLog))
+			clientService := NewClientService(nil, nil, clients.NewClientRepository([]*clients.Client{c1, c2}, &hour, testLog), testLog)
 			al := APIListener{
 				insecureForTests: true,
 				Server: &Server{

--- a/server/api_handler_tunnels.go
+++ b/server/api_handler_tunnels.go
@@ -32,11 +32,11 @@ func (al *APIListener) handleGetTunnels(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	clinetGroups, err := al.clientGroupProvider.GetAll(req.Context())
+	clientGroups, err := al.clientGroupProvider.GetAll(req.Context())
 	if err != nil {
 		al.jsonError(w, err)
 	}
-	clients, err := al.clientService.GetUserClients(clinetGroups, curUser)
+	clients, err := al.clientService.GetUserClients(clientGroups, curUser)
 	if err != nil {
 		al.jsonError(w, err)
 		return

--- a/server/api_listener.go
+++ b/server/api_listener.go
@@ -47,6 +47,8 @@ const (
 
 type APIListener struct {
 	*logger.Logger
+	errResponseLogger *logger.Logger
+
 	*Server
 
 	fingerprint       string
@@ -190,6 +192,8 @@ func NewAPIListener(
 		commandManager:    commandManager,
 		storedTunnels:     storedtunnels.New(server.clientDB),
 	}
+
+	a.errResponseLogger = server.Logger.Fork("error-response")
 
 	if config.API.IsTwoFAOn() {
 		var msgSrv message.Service

--- a/server/api_responses.go
+++ b/server/api_responses.go
@@ -4,25 +4,15 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"os"
 
 	"github.com/cloudradar-monitoring/rport/server/api"
 	errors2 "github.com/cloudradar-monitoring/rport/server/api/errors"
 	"github.com/cloudradar-monitoring/rport/share/logger"
 )
 
-var (
-	// this will be used by default for tests, but otherwise should be overridden during server init
-	errLog = logger.NewLogger("api-error-response", logger.LogOutput{File: os.Stdout}, logger.LogLevelDebug)
-)
-
-func SetAPIResponsesErrorLog(l *logger.Logger) {
-	errLog = l
-}
-
-func writeErrorPayloadLog(errPayload api.ErrorPayload) {
-	if errLog != nil && errLog.Level == logger.LogLevelDebug {
-		errLog.Debugf("payload: %+v", errPayload)
+func (al *APIListener) writeErrorResponseLog(errPayload api.ErrorPayload) {
+	if al.errResponseLogger != nil && al.errResponseLogger.Level == logger.LogLevelDebug {
+		al.errResponseLogger.Debugf("payload: %+v", errPayload)
 	}
 }
 
@@ -42,7 +32,7 @@ func (al *APIListener) writeJSONResponse(w http.ResponseWriter, statusCode int, 
 
 func (al *APIListener) jsonErrorResponse(w http.ResponseWriter, statusCode int, err error) {
 	errPayload := api.NewErrAPIPayloadFromError(err, "", "")
-	writeErrorPayloadLog(errPayload)
+	al.writeErrorResponseLog(errPayload)
 	al.writeJSONResponse(w, statusCode, errPayload)
 }
 
@@ -63,25 +53,25 @@ func (al *APIListener) jsonError(w http.ResponseWriter, err error) {
 	}
 
 	errPayload := api.NewErrAPIPayloadFromError(err, errCode, "")
-	writeErrorPayloadLog(errPayload)
+	al.writeErrorResponseLog(errPayload)
 	al.writeJSONResponse(w, statusCode, errPayload)
 }
 
 func (al *APIListener) jsonErrorResponseWithErrCode(w http.ResponseWriter, statusCode int, errCode, title string) {
 	errPayload := api.NewErrAPIPayloadFromMessage(errCode, title, "")
-	writeErrorPayloadLog(errPayload)
+	al.writeErrorResponseLog(errPayload)
 	al.writeJSONResponse(w, statusCode, errPayload)
 }
 
 func (al *APIListener) jsonErrorResponseWithTitle(w http.ResponseWriter, statusCode int, title string) {
 	errPayload := api.NewErrAPIPayloadFromMessage("", title, "")
-	writeErrorPayloadLog(errPayload)
+	al.writeErrorResponseLog(errPayload)
 	al.writeJSONResponse(w, statusCode, errPayload)
 }
 
 func (al *APIListener) jsonErrorResponseWithDetail(w http.ResponseWriter, statusCode int, errCode, title, detail string) {
 	errPayload := api.NewErrAPIPayloadFromMessage(errCode, title, detail)
-	writeErrorPayloadLog(errPayload)
+	al.writeErrorResponseLog(errPayload)
 	al.writeJSONResponse(w, statusCode, errPayload)
 }
 
@@ -91,6 +81,6 @@ func (al *APIListener) jsonErrorResponseWithError(w http.ResponseWriter, statusC
 		detail = err.Error()
 	}
 	errPayload := api.NewErrAPIPayloadFromMessage("", title, detail)
-	writeErrorPayloadLog(errPayload)
+	al.writeErrorResponseLog(errPayload)
 	al.writeJSONResponse(w, statusCode, errPayload)
 }

--- a/server/client_listener.go
+++ b/server/client_listener.go
@@ -210,7 +210,7 @@ func (cl *ClientListener) handleWebsocket(w http.ResponseWriter, req *http.Reque
 	clog.Debugf("Handshaking...")
 	sshConn, chans, reqs, err := ssh.NewServerConn(conn, cl.sshConfig)
 	if err != nil {
-		cl.Debugf("Failed to handshake (%s)", err)
+		cl.Debugf("Failed to handshake (%s) from %s", err, conn.RemoteAddr().String())
 		return
 	}
 	//verify configuration

--- a/server/client_listener.go
+++ b/server/client_listener.go
@@ -490,7 +490,7 @@ func (cl *ClientListener) saveCmdResult(respBytes []byte) (*models.Job, error) {
 			// proceed further
 		}
 	} else {
-		cl.Debugf("%s, WS conn not found", resp.LogPrefix())
+		cl.Debugf("%s, WS conn not found when saving command result. No active listeners connected", resp.LogPrefix())
 	}
 
 	err = cl.jobProvider.SaveJob(&resp)
@@ -590,7 +590,7 @@ func (cl *ClientListener) handleOutputChannel(typ string, jobData []byte, client
 				// proceed further
 			}
 		} else {
-			clientLog.Debugf("WS conn not found")
+			clientLog.Debugf("WS conn not found handling output channel. No active listeners connected")
 		}
 	}
 	return nil

--- a/server/client_service.go
+++ b/server/client_service.go
@@ -341,6 +341,7 @@ func (s *ClientServiceProvider) StartClient(
 	client.Context = ctx
 	client.Logger = clog
 
+	client.SetConnected()
 	_, err = s.startClientTunnels(client, req.Remotes)
 	if err != nil {
 		return nil, err
@@ -453,7 +454,7 @@ func (s *ClientServiceProvider) Terminate(client *clients.Client) error {
 	}
 
 	now := time.Now()
-	client.DisconnectedAt = &now
+	client.SetDisconnected(&now)
 
 	// Do not save if client doesn't exist in repo - it was force deleted
 	existing, err := s.repo.GetByID(client.ID)

--- a/server/client_service.go
+++ b/server/client_service.go
@@ -444,7 +444,7 @@ func (s *ClientServiceProvider) checkLocalPort(protocol, port string) error {
 }
 
 func (s *ClientServiceProvider) Terminate(client *clients.Client) error {
-	s.logger.Debugf("terminating client: %s", client.ID)
+	s.logger.Infof("terminating client: %s", client.ID)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/server/client_service.go
+++ b/server/client_service.go
@@ -158,7 +158,7 @@ func NewClientService(
 		tunnelProxyConfig: tunnelProxyConfig,
 		portDistributor:   portDistributor,
 		repo:              repo,
-		logger:            logger,
+		logger:            logger.Fork("client-service"),
 	}
 }
 
@@ -175,7 +175,7 @@ func InitClientService(
 		return nil, fmt.Errorf("failed to init Client Repository: %v", err)
 	}
 
-	return NewClientService(tunnelProxyConfig, portDistributor, repo, logger.Fork("client-service")), nil
+	return NewClientService(tunnelProxyConfig, portDistributor, repo, logger), nil
 }
 
 func (s *ClientServiceProvider) Count() (int, error) {

--- a/server/client_service_test.go
+++ b/server/client_service_test.go
@@ -172,7 +172,8 @@ func TestDeleteOfflineClient(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
-			clientService := NewClientService(nil, nil, clients.NewClientRepository([]*clients.Client{c1Active, c2Active, c3Offline, c4Offline}, &hour, testLog))
+			clientRepo := clients.NewClientRepository([]*clients.Client{c1Active, c2Active, c3Offline, c4Offline}, &hour, testLog)
+			clientService := NewClientService(nil, nil, clientRepo, testLog)
 			before, err := clientService.Count()
 			require.NoError(t, err)
 			require.Equal(t, 4, before)
@@ -359,7 +360,7 @@ func TestCheckClientsAccess(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// given
-			clientService := NewClientService(nil, nil, clients.NewClientRepository(allClients, nil, testLog))
+			clientService := NewClientService(nil, nil, clients.NewClientRepository(allClients, nil, testLog), testLog)
 
 			// when
 			gotErr := clientService.CheckClientsAccess(tc.clients, tc.user, clientGroups)

--- a/server/client_status_check.go
+++ b/server/client_status_check.go
@@ -93,7 +93,9 @@ func (t *ClientsStatusCheckTask) PingClients(jobs <-chan *clients.Client, result
 		}
 		// None of the above. Ping must have failed or timed out.
 		t.log.Infof("ping to %s [%s] failed: %s", j.Name, j.ID, err)
-		j.DisconnectedAt = &now
+
+		j.SetDisconnected(&now)
+
 		j.Close()
 		results <- false
 	}

--- a/server/clients/client.go
+++ b/server/clients/client.go
@@ -82,6 +82,18 @@ type CalculatedClient struct {
 	ConnectionState ConnectionState `json:"connection_state"`
 }
 
+func (c *Client) SetConnected() {
+	c.Logger.Debugf("%s: set to connected at %s", c.ID, time.Now())
+	c.DisconnectedAt = nil
+}
+
+func (c *Client) SetDisconnected(at *time.Time) {
+	if c.Logger != nil {
+		c.Logger.Debugf("%s: set to disconnected at %s", c.ID, *at)
+	}
+	c.DisconnectedAt = at
+}
+
 func (c *Client) ToCalculated(allGroups []*cgroups.ClientGroup) *CalculatedClient {
 	clientGroups := []string{}
 	for _, group := range allGroups {

--- a/server/clients/cr.go
+++ b/server/clients/cr.go
@@ -66,6 +66,8 @@ func InitClientRepository(
 }
 
 func (s *ClientRepository) Save(client *Client) error {
+	s.logger.Debugf("saving client: %s: %s", client.ID, client.DisconnectedAt)
+
 	if s.provider != nil {
 		err := s.provider.Save(context.Background(), client)
 		if err != nil {
@@ -80,6 +82,8 @@ func (s *ClientRepository) Save(client *Client) error {
 }
 
 func (s *ClientRepository) Delete(client *Client) error {
+	s.logger.Debugf("deleting client: %s: %s", client.ID, client.DisconnectedAt)
+
 	if s.provider != nil {
 		err := s.provider.Delete(context.Background(), client.ID)
 		if err != nil {
@@ -158,6 +162,8 @@ func findMatchingORClients(availableClients []*Client, tags []string) (matchingC
 // DeleteObsolete deletes obsolete disconnected clients and returns them.
 func (s *ClientRepository) DeleteObsolete() ([]*Client, error) {
 	if s.provider != nil {
+		s.logger.Debugf("deleting obsolete clients")
+
 		err := s.provider.DeleteObsolete(context.Background())
 		if err != nil {
 			return nil, fmt.Errorf("failed to delete obsolete clients: %w", err)
@@ -169,6 +175,8 @@ func (s *ClientRepository) DeleteObsolete() ([]*Client, error) {
 	var deleted []*Client
 	for _, client := range s.clients {
 		if client.Obsolete(s.KeepDisconnectedClients) {
+			s.logger.Debugf("deleting obsolete client: %s: %s", client.ID, client.DisconnectedAt)
+
 			delete(s.clients, client.ID)
 			deleted = append(deleted, client)
 		}

--- a/server/clients/cr.go
+++ b/server/clients/cr.go
@@ -46,7 +46,7 @@ func NewClientRepositoryWithDB(initClients []*Client, keepDisconnectedClients *t
 		clients:                 clients,
 		KeepDisconnectedClients: keepDisconnectedClients,
 		provider:                provider,
-		logger:                  logger,
+		logger:                  logger.Fork("client-repo"),
 	}
 }
 

--- a/server/clients/init.go
+++ b/server/clients/init.go
@@ -16,7 +16,7 @@ func GetInitState(ctx context.Context, p ClientProvider) ([]*Client, error) {
 	now := now()
 	for _, cur := range all {
 		if cur.DisconnectedAt == nil {
-			cur.DisconnectedAt = &now
+			cur.SetDisconnected(&now)
 			err := p.Save(ctx, cur)
 			if err != nil {
 				return nil, fmt.Errorf("failed to save client: %v", err)

--- a/server/server.go
+++ b/server/server.go
@@ -90,6 +90,8 @@ func NewServer(ctx context.Context, config *chconfig.Config, opts *ServerOpts) (
 		},
 	}
 
+	SetAPIResponsesErrorLog(s.Logger.Fork("api-error-response"))
+
 	filesAPI := opts.FilesAPI
 	s.plusManager = opts.PlusManager
 

--- a/server/server.go
+++ b/server/server.go
@@ -90,8 +90,6 @@ func NewServer(ctx context.Context, config *chconfig.Config, opts *ServerOpts) (
 		},
 	}
 
-	SetAPIResponsesErrorLog(s.Logger.Fork("api-error-response"))
-
 	filesAPI := opts.FilesAPI
 	s.plusManager = opts.PlusManager
 

--- a/server/upload_test.go
+++ b/server/upload_test.go
@@ -345,6 +345,7 @@ func TestHandleFileUploads(t *testing.T) {
 						nil,
 						nil,
 						clients.NewClientRepository([]*clients.Client{cl}, &hour, testLog),
+						testLog,
 					),
 					clientGroupProvider: mockClientGroupProvider{},
 					config: &chconfig.Config{

--- a/share/logger/logger.go
+++ b/share/logger/logger.go
@@ -14,6 +14,19 @@ const (
 	LogLevelDebug LogLevel = 2
 )
 
+func (l LogLevel) String() string {
+	switch l {
+	case LogLevelInfo:
+		return "info"
+	case LogLevelDebug:
+		return "debug"
+	case LogLevelError:
+		return "error"
+	default:
+		return ""
+	}
+}
+
 func ParseLogLevel(str string) (LogLevel, error) {
 	var m = map[string]LogLevel{
 		"error": LogLevelError,
@@ -88,7 +101,7 @@ func (l *Logger) Debugf(f string, args ...interface{}) {
 
 func (l *Logger) Logf(severity LogLevel, f string, args ...interface{}) {
 	if l.level >= severity {
-		l.logger.Printf(l.prefix+": "+f, args...)
+		l.logger.Printf(severity.String()+": "+l.prefix+": "+f, args...)
 	}
 }
 

--- a/share/logger/logger.go
+++ b/share/logger/logger.go
@@ -74,7 +74,7 @@ type Logger struct {
 	prefix string
 	logger *log.Logger
 	output LogOutput
-	level  LogLevel
+	Level  LogLevel
 }
 
 func NewLogger(prefix string, output LogOutput, level LogLevel) *Logger {
@@ -82,7 +82,7 @@ func NewLogger(prefix string, output LogOutput, level LogLevel) *Logger {
 		prefix: prefix,
 		logger: log.New(output.File, "", log.Ldate|log.Ltime),
 		output: output,
-		level:  level,
+		Level:  level,
 	}
 	return l
 }
@@ -100,7 +100,7 @@ func (l *Logger) Debugf(f string, args ...interface{}) {
 }
 
 func (l *Logger) Logf(severity LogLevel, f string, args ...interface{}) {
-	if l.level >= severity {
+	if l.Level >= severity {
 		l.logger.Printf(severity.String()+": "+l.prefix+": "+f, args...)
 	}
 }
@@ -108,7 +108,7 @@ func (l *Logger) Logf(severity LogLevel, f string, args ...interface{}) {
 func (l *Logger) Fork(prefix string, args ...interface{}) *Logger {
 	//slip the parent prefix at the front
 	args = append([]interface{}{l.prefix}, args...)
-	ll := NewLogger(fmt.Sprintf("%s: "+prefix, args...), l.output, l.level)
+	ll := NewLogger(fmt.Sprintf("%s: "+prefix, args...), l.output, l.Level)
 	return ll
 }
 

--- a/share/logger/logger_test.go
+++ b/share/logger/logger_test.go
@@ -21,8 +21,9 @@ func TestLogger(t *testing.T) {
 	logger.Errorf("Error %s", "Error")
 
 	log, err := os.ReadFile(logfile)
+
 	require.NoError(t, err, "error reading log file")
-	assert.Contains(t, string(log), "test: Debug Debug")
-	assert.Contains(t, string(log), "test: Info Info")
-	assert.Contains(t, string(log), "test: Error Error")
+	assert.Contains(t, string(log), "debug: test: Debug Debug")
+	assert.Contains(t, string(log), "info: test: Info Info")
+	assert.Contains(t, string(log), "error: test: Error Error")
 }


### PR DESCRIPTION
This PR improves aspects of our general logging approach. We have a customer who's having problems with disconnected clients and connected tunnels being out of sync. It is proving difficult to diagnose as our logs are missing certain information about client disconnects / connects. This PR adds some of the missing info.

The PR also contains a change that isn't specifically related to improved logging that might assist with the customer problem where we will attempt to start tunnels even if the client is marked as disconnected. Ideally this would be a separate PR but in the interests of deploying a change quickly, it has been included with PR.

Also, there is a change, that will be enhanced further after the next pre-release, to log api error responses on the server side. We currently have a number of internal server error responses that aren't logged on the server. A future change will move these logs out from the server log into a separate (and configurable) api responses log.