### PR TITLE
Fix/dev 2715 slowloris attack

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,5 +14,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.46.2
+          version: v1.50.1
           args: -c .golangci.yml

--- a/server/clients/clienttunnel/tunnel_proxy.go
+++ b/server/clients/clienttunnel/tunnel_proxy.go
@@ -109,8 +109,9 @@ func (tp *TunnelProxy) Start(ctx context.Context) error {
 	router = tp.tunnelProxyConnector.InitRouter(router)
 
 	tp.proxyServer = &http.Server{
-		Addr:    tp.Addr(),
-		Handler: router,
+		Addr:              tp.Addr(),
+		Handler:           router,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	go func() {

--- a/share/http_server.go
+++ b/share/http_server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"time"
 )
 
 type ServerOption func(*HTTPServer)
@@ -31,7 +32,7 @@ type HTTPServer struct {
 // NewHTTPServer creates a new HTTPServer
 func NewHTTPServer(maxHeaderBytes int, options ...ServerOption) *HTTPServer {
 	s := &HTTPServer{
-		Server:   &http.Server{MaxHeaderBytes: maxHeaderBytes},
+		Server:   &http.Server{MaxHeaderBytes: maxHeaderBytes, ReadHeaderTimeout: 5 * time.Second},
 		listener: nil,
 		running:  make(chan error, 1),
 	}


### PR DESCRIPTION
Seems to be an easy fix. Because only the header time out is affected, it should not have any negative consequences on client connections. 5 sec seems a reasonable value to me. 