### PR TITLE
Fix/dev 2723 windows client process dead but running

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -509,11 +509,11 @@ func (c *Client) showConnectionError(connerr error, attempt int) {
 	//show error and attempt counts
 	msg := fmt.Sprintf("Connection error: %s", connerr)
 	if attempt > 0 {
-		msg += fmt.Sprintf(" (Attempt: %d", attempt)
-		if maxAttempt > 0 {
-			msg += fmt.Sprintf("/%d", maxAttempt)
+		maxAttemptStr := string(maxAttempt)
+		if maxAttempt < 0 {
+			maxAttemptStr = "∞"
 		}
-		msg += ")"
+		msg += fmt.Sprintf(" (Attempt: %d of %s)", attempt, maxAttemptStr)
 	}
 	c.Errorf(msg)
 	if strings.Contains(msg, "previous session was not properly closed") {

--- a/client/client.go
+++ b/client/client.go
@@ -33,6 +33,8 @@ import (
 	"github.com/cloudradar-monitoring/rport/share/models"
 )
 
+const ConnectionTimeout = 10 * time.Second
+
 // Client represents a client instance
 type Client struct {
 	*logger.Logger
@@ -148,7 +150,7 @@ func (c *Client) keepAliveLoop() {
 		if c.sshConn != nil {
 			ok, _, rtt, err := comm.PingConnectionWithTimeout(c.sshConn, c.configHolder.Connection.KeepAliveTimeout)
 			if err != nil || !ok {
-				c.Errorf("Failed to keepalive (client to server ping): %s", err)
+				c.Errorf("Failed to send keepalive (client to server ping): %s", err)
 				c.sshConn.Close()
 			} else {
 				msg := fmt.Sprintf("ping to %s succeeded within %s", c.sshConn.RemoteAddr(), rtt)
@@ -366,12 +368,14 @@ func (c *Client) sendConnectionRequest(ctx context.Context, sshConn ssh.Conn) er
 	if err != nil {
 		return fmt.Errorf("could not encode connection request: %v", err)
 	}
-	c.Debugf("Sending connection request: %+v", string(req))
+	c.Infof("Sending connection request.")
+	c.Debugf("Sending connection request with client details %s", string(req))
 	t0 := time.Now()
-	replyOk, respBytes, err := sshConn.SendRequest("new_connection", true, req)
+	replyOk, respBytes, err := comm.SendRequestWithTimeout(sshConn, "new_connection", true, req, ConnectionTimeout)
 	if err != nil {
-		return fmt.Errorf("connection request verification failed: %v", err)
+		return retryableError{err}
 	}
+	c.Debugf("Connection request has been answered successfully.")
 	if !replyOk {
 		msg := string(respBytes)
 
@@ -509,7 +513,7 @@ func (c *Client) showConnectionError(connerr error, attempt int) {
 	//show error and attempt counts
 	msg := fmt.Sprintf("Connection error: %s", connerr)
 	if attempt > 0 {
-		maxAttemptStr := string(maxAttempt)
+		maxAttemptStr := fmt.Sprint(maxAttempt)
 		if maxAttempt < 0 {
 			maxAttemptStr = "∞"
 		}

--- a/server/client_status_check_test.go
+++ b/server/client_status_check_test.go
@@ -119,5 +119,5 @@ func TestClientsStatusDeterminationTask(t *testing.T) {
 	t.Logf("c4: DisconnectedAt: %s", c4.DisconnectedAt)
 	log, err := os.ReadFile(logfile)
 	assert.NoError(t, err, "error reading log file")
-	assert.Contains(t, string(log), fmt.Sprintf("ping to  [4] failed: timeout %s exceeded", timeout))
+	assert.Contains(t, string(log), fmt.Sprintf("ping to  [4] failed: conn.SendRequest(ping), timeout %s exceeded", timeout))
 }

--- a/share/comm/ping.go
+++ b/share/comm/ping.go
@@ -1,36 +1,13 @@
 package comm
 
 import (
-	"context"
-	"fmt"
 	"time"
 
 	"golang.org/x/crypto/ssh"
 )
 
-func PingConnectionWithTimeout(conn ssh.Conn, timeout time.Duration) (bool, []byte, time.Duration, error) {
-	var (
-		ok         bool
-		response   []byte
-		err        error
-		timerStart = time.Now()
-	)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ch := make(chan bool, 1)
-	go func() {
-		ok, response, err = conn.SendRequest(RequestTypePing, true, nil)
-		select {
-		default:
-			ch <- true
-		case <-ctx.Done():
-			return
-		}
-	}()
-	select {
-	case <-ch:
-		return ok, response, time.Since(timerStart), err
-	case <-time.After(timeout):
-		return false, nil, 0, fmt.Errorf("timeout %s exceeded", timeout)
-	}
+func PingConnectionWithTimeout(conn ssh.Conn, timeout time.Duration) (ok bool, response []byte, rtt time.Duration, err error) {
+	timerStart := time.Now()
+	ok, response, err = SendRequestWithTimeout(conn, RequestTypePing, true, nil, timeout)
+	return ok, response, time.Since(timerStart), err
 }


### PR DESCRIPTION
I've seen logs where the client seems to get stuck on the initial connection. Because of the missing time out, the client never retries. 
Furthermore, I'm wondering why a connection error on `client/client.go:376` was not considered a retriable error. On errors, the client was terminating there. I think there is no reason why a client should stop retrying. 