### PR TITLE
[DEV-2687] Add input and output encoding config options for interpreter aliases

### DIFF
--- a/client/config_test.go
+++ b/client/config_test.go
@@ -748,7 +748,7 @@ func TestConfigParseInterpreterAliases(t *testing.T) {
 			},
 		},
 		{
-			Name:   "input and ouput encoding",
+			Name:   "input and output encoding",
 			Config: []any{"/bin/bash", "windows-1252", "cp437"},
 			ExpectedAliases: map[string]string{
 				alias: "/bin/bash",

--- a/client/system/encoding_nix.go
+++ b/client/system/encoding_nix.go
@@ -5,12 +5,10 @@ package system
 
 import (
 	"context"
-
-	"golang.org/x/text/encoding"
 )
 
 // DetectConsoleEncoding returns encoding that interpreter is using. Returns nil, if it's UTF-8
-func DetectConsoleEncoding(ctx context.Context, interpreter Interpreter) (encoding.Encoding, encoding.Encoding, error) {
+func DetectConsoleEncoding(ctx context.Context, interpreter Interpreter) (*ShellEncoding, error) {
 	// impl only for windows
-	return nil, nil, nil
+	return nil, nil
 }

--- a/client/system/encoding_win.go
+++ b/client/system/encoding_win.go
@@ -12,30 +12,36 @@ import (
 )
 
 // DetectConsoleEncoding returns input and output encoding that interpreter is using. Returns nil, if it's UTF-8
-func DetectConsoleEncoding(ctx context.Context, interpreter Interpreter) (encoding.Encoding, encoding.Encoding, error) {
+func DetectConsoleEncoding(ctx context.Context, interpreter Interpreter) (*ShellEncoding, error) {
 	commandInput, commandOutput := detectEncodingCommand(interpreter)
 
 	// use utf-8 if detection is not supported for interpreter
 	if len(commandInput) == 0 {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	input, err := detectEncoding(ctx, interpreter, commandInput)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	// empty output command implies same encoding
+	// empty command for output encoding implies same encoding
 	if len(commandOutput) == 0 {
-		return input, input, nil
+		return &ShellEncoding{
+			InputEncoding:  input,
+			OutputEncoding: input,
+		}, nil
 	}
 
 	output, err := detectEncoding(ctx, interpreter, commandOutput)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return input, output, nil
+	return &ShellEncoding{
+		InputEncoding:  input,
+		OutputEncoding: output,
+	}, nil
 }
 
 func detectEncoding(ctx context.Context, interpreter Interpreter, command []string) (encoding.Encoding, error) {

--- a/client/system/script.go
+++ b/client/system/script.go
@@ -17,7 +17,7 @@ import (
 const DefaultFileMode = os.FileMode(0540)
 const DefaultDirMode = os.FileMode(0700)
 
-func CreateScriptFile(scriptDir, scriptContent string, interpreter Interpreter, enc encoding.Encoding) (filePath string, err error) {
+func CreateScriptFile(scriptDir, scriptContent string, interpreter Interpreter, enc *encoding.Encoder) (filePath string, err error) {
 	err = ValidateScriptDir(scriptDir)
 	if err != nil {
 		return "", err
@@ -32,7 +32,7 @@ func CreateScriptFile(scriptDir, scriptContent string, interpreter Interpreter, 
 
 	byteContent := []byte(scriptContent)
 	if enc != nil {
-		byteContent, err = enc.NewEncoder().Bytes(byteContent)
+		byteContent, err = enc.Bytes(byteContent)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/rport/main.go
+++ b/cmd/rport/main.go
@@ -68,7 +68,7 @@ var clientHelp = `
     starts client with configuration loaded from the file
 
   Options:
-    NOTE: The order of options is important. <SERVER>:<PORT> and <REMOTES> aka the tunnels 
+    NOTE: The order of options is important. <SERVER>:<PORT> and <REMOTES> aka the tunnels
     must be the last options on the command line.
 
     --fingerprint, A *strongly recommended* fingerprint string

--- a/rport.example.conf
+++ b/rport.example.conf
@@ -279,8 +279,11 @@
   ## you can specify aliases. Instead of providing the full path to the shell,
   ## sending the alias is sufficient.
   ## https://oss.rport.io/get-started/scripts/#customizing-an-interpreter
+  ## Optionally you can also specify input and output encoding.
+  ## If only one encoding is specified it will be used for both input and output.
   ## Examples:
   # pwsh7 = 'C:\Program Files\PowerShell\7\pwsh.exe'
+  # pwsh7enc = ['C:\Program Files\PowerShell\7\pwsh.exe', 'windows-1252', 'cp437']
   # bash = 'C:\Program Files\Git\bin\bash.exe'
 
 [file-reception]

--- a/share/clientconfig/client_config.go
+++ b/share/clientconfig/client_config.go
@@ -11,15 +11,18 @@ import (
 )
 
 type Config struct {
-	Client              ClientConfig        `json:"client" mapstructure:"client"`
-	Connection          ConnectionConfig    `json:"connection" mapstructure:"connection"`
-	Logging             LogConfig           `json:"logging" mapstructure:"logging"`
-	RemoteCommands      CommandsConfig      `json:"remote_commands" mapstructure:"remote-commands"`
-	RemoteScripts       ScriptsConfig       `json:"remote_scripts" mapstructure:"remote-scripts"`
-	Monitoring          MonitoringConfig    `json:"monitoring" mapstructure:"monitoring"`
-	Tunnels             TunnelsConfig       `json:"-"`
-	InterpreterAliases  map[string]string   `json:"interpreter_aliases" mapstructure:"interpreter-aliases"`
-	FileReceptionConfig FileReceptionConfig `json:"file_reception" mapstructure:"file-reception"`
+	Client                   ClientConfig        `json:"client" mapstructure:"client"`
+	Connection               ConnectionConfig    `json:"connection" mapstructure:"connection"`
+	Logging                  LogConfig           `json:"logging" mapstructure:"logging"`
+	RemoteCommands           CommandsConfig      `json:"remote_commands" mapstructure:"remote-commands"`
+	RemoteScripts            ScriptsConfig       `json:"remote_scripts" mapstructure:"remote-scripts"`
+	Monitoring               MonitoringConfig    `json:"monitoring" mapstructure:"monitoring"`
+	Tunnels                  TunnelsConfig       `json:"-"`
+	InterpreterAliasesConfig map[string]any      `json:"-" mapstructure:"interpreter-aliases"`
+	FileReceptionConfig      FileReceptionConfig `json:"file_reception" mapstructure:"file-reception"`
+
+	InterpreterAliases          map[string]string                   `json:"interpreter_aliases"`
+	InterpreterAliasesEncodings map[string]InterpreterAliasEncoding `json:"interpreter_aliases_encodings"`
 }
 
 type ClientConfig struct {
@@ -105,4 +108,9 @@ type MonitoringConfig struct {
 type FileReceptionConfig struct {
 	Protected []string `json:"protected" mapstructure:"protected"`
 	Enabled   bool     `json:"enabled" mapstructure:"enabled"`
+}
+
+type InterpreterAliasEncoding struct {
+	InputEncoding  string `json:"input_encoding"`
+	OutputEncoding string `json:"output_encoding"`
 }


### PR DESCRIPTION
https://tracker.rport.io/issue/DEV-2687/broken-support-for-special-characters-on-windows