### PR TITLE
[DEV-2760] Add log on client when tunnel is not allowed

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -503,6 +503,9 @@ func (c *Client) checkTunnelAllowed(payload []byte) (*comm.CheckTunnelAllowedRes
 	if err != nil {
 		return nil, err
 	}
+	if !allowed {
+		c.Infof(`Tunnel to %s not allowed based on "tunnel_allowed" config: %v`, req.Remote, c.configHolder.Client.TunnelAllowed)
+	}
 
 	return &comm.CheckTunnelAllowedResponse{
 		IsAllowed: allowed,
@@ -557,7 +560,7 @@ func (c *Client) connectStreams(chans <-chan ssh.NewChannel) {
 			c.Errorf("Could not check if remote is allowed: %v", err)
 		}
 		if !allowed {
-			c.Infof(`Rejecting stream to %s based on "tunnel_allowed" config.`, remote)
+			c.Infof(`Rejecting stream to %s based on "tunnel_allowed" config: %v`, remote, c.configHolder.Client.TunnelAllowed)
 			err := ch.Reject(ssh.Prohibited, `not allowed with "tunnel_allowed" config`)
 			if err != nil {
 				c.Errorf("Failed to reject stream: %v", err)

--- a/client/client.go
+++ b/client/client.go
@@ -504,7 +504,7 @@ func (c *Client) checkTunnelAllowed(payload []byte) (*comm.CheckTunnelAllowedRes
 		return nil, err
 	}
 	if !allowed {
-		c.Infof(`Tunnel to %s not allowed based on "tunnel_allowed" config: %v`, req.Remote, c.configHolder.Client.TunnelAllowed)
+		c.Errorf(`Tunnel to %q not allowed based on "tunnel_allowed" config: %v`, req.Remote, c.configHolder.Client.TunnelAllowed)
 	}
 
 	return &comm.CheckTunnelAllowedResponse{
@@ -560,7 +560,7 @@ func (c *Client) connectStreams(chans <-chan ssh.NewChannel) {
 			c.Errorf("Could not check if remote is allowed: %v", err)
 		}
 		if !allowed {
-			c.Infof(`Rejecting stream to %s based on "tunnel_allowed" config: %v`, remote, c.configHolder.Client.TunnelAllowed)
+			c.Errorf(`Rejecting stream to %q based on "tunnel_allowed" config: %v`, remote, c.configHolder.Client.TunnelAllowed)
 			err := ch.Reject(ssh.Prohibited, `not allowed with "tunnel_allowed" config`)
 			if err != nil {
 				c.Errorf("Failed to reject stream: %v", err)


### PR DESCRIPTION
https://tracker.rport.io/issue/DEV-2760/Tunnel-destination-is-not-allowed-by-client-configuration-after-ONE-Tunnel-Works